### PR TITLE
Startup env compatibility for rename transition

### DIFF
--- a/Start.bat
+++ b/Start.bat
@@ -3,11 +3,28 @@ REM set "AEROFOIL_VERSION=dev"
 REM set "AEROFOIL_TRUST_PROXY_HEADERS=1"
 REM set "AEROFOIL_TRUSTED_PROXIES=127.0.0.1,192.168.1.0/24"
 
-REM Reuse an existing key if it is already set in the current environment.
+REM Keep backward compatibility with legacy OWNFOIL_SECRET_KEY while preferring AEROFOIL_SECRET_KEY.
+set "PERSIST_AEROFOIL_SECRET_KEY=0"
+if not defined AEROFOIL_SECRET_KEY (
+    if defined OWNFOIL_SECRET_KEY (
+        set "AEROFOIL_SECRET_KEY=%OWNFOIL_SECRET_KEY%"
+        set "PERSIST_AEROFOIL_SECRET_KEY=1"
+    )
+)
+
+REM Reuse an existing key if it is already set in the current environment or persisted registry.
 if not defined AEROFOIL_SECRET_KEY (
     REM Fallback: try to read a persisted user-level key from the registry.
     for /f "tokens=2,*" %%A in ('reg query "HKCU\Environment" /v AEROFOIL_SECRET_KEY 2^>nul ^| findstr /I "AEROFOIL_SECRET_KEY"') do (
         set "AEROFOIL_SECRET_KEY=%%B"
+    )
+)
+
+REM Legacy fallback: migrate persisted OWNFOIL_SECRET_KEY to AEROFOIL_SECRET_KEY.
+if not defined AEROFOIL_SECRET_KEY (
+    for /f "tokens=2,*" %%A in ('reg query "HKCU\Environment" /v OWNFOIL_SECRET_KEY 2^>nul ^| findstr /I "OWNFOIL_SECRET_KEY"') do (
+        set "AEROFOIL_SECRET_KEY=%%B"
+        set "PERSIST_AEROFOIL_SECRET_KEY=1"
     )
 )
 
@@ -22,8 +39,12 @@ if not defined AEROFOIL_SECRET_KEY (
         exit /b 1
     )
 
+    set "PERSIST_AEROFOIL_SECRET_KEY=1"
+)
+
+if "%PERSIST_AEROFOIL_SECRET_KEY%"=="1" (
     setx AEROFOIL_SECRET_KEY "%AEROFOIL_SECRET_KEY%" >nul 2>&1
-    echo Generated and persisted AEROFOIL_SECRET_KEY for this user.
+    echo Persisted AEROFOIL_SECRET_KEY for this user.
 )
 
 set "AEROFOIL_WSGI_THREADS=32"


### PR DESCRIPTION
This PR implements a Window-only way of generating a fresh Secret Key, instead of hardcoding one. 
The change also keeps backward compatibility for users upgrading from _old project name_-era environment variables, while making `AEROFOIL_*` names the default moving forward.

  ## What changed

  - Updated Windows startup flow to prefer AEROFOIL_SECRET_KEY, but still accept legacy OWNFOIL_SECRET_KEY.
  - Added migration behavior on Windows: when a legacy key is found, it is persisted as AEROFOIL_SECRET_KEY.
  - Updated start.sh precedence to avoid breaking existing setups:
      1. --flask-key CLI argument
      2. AEROFOIL_SECRET_KEY
      3. OWNFOIL_SECRET_KEY
      4. built-in fallback

  ## Commit details

  - 8784f42 chore(windows): generate and persist AEROFOIL_SECRET_KEY on first run
  - e628262 chore(startup): keep OWNFOIL secret env fallback while preferring AEROFOIL
