### PR TITLE
fix: support wrapped content files

### DIFF
--- a/app/downloads/manager.py
+++ b/app/downloads/manager.py
@@ -21,6 +21,7 @@ from app.downloads.client import (
 from app.downloads.prowlarr import ProwlarrClient, filter_results, pick_best_result
 from app.library import _ensure_unique_path, _sanitize_component, enqueue_cleanup_roots, enqueue_organize_paths
 from app.settings import load_settings
+from app.utils import get_supported_content_extension, is_supported_content_path, is_wrapped_content_path
 
 logger = logging.getLogger("downloads.manager")
 
@@ -987,7 +988,6 @@ def _build_restored_pending_key(item):
     label = _normalize_match_text((item or {}).get("name")) or "unknown"
     return f"restored:{protocol}:{client_type}:name:{label}"
 
-
 def _restore_pending_from_active(downloads):
     _ensure_downloads_state_loaded()
     poll_targets = _get_completed_poll_targets(downloads)
@@ -1285,6 +1285,9 @@ def _process_tracked_completed_item_locked(key, info, bucket):
         return []
 
     _update_pending_live_metadata(info, item=match, status="completed")
+    matched_id = match.get("id") or match.get("hash")
+    if matched_id:
+        bucket["matched_ids"].add(matched_id)
     move_info = _resolve_completed_update_info(info, match)
     moved_result, move_reason = _move_completed_with_reason(match, move_info)
     moved_match_paths = _coerce_moved_paths(moved_result)
@@ -1297,9 +1300,6 @@ def _process_tracked_completed_item_locked(key, info, bucket):
         _set_pending_stuck(info, move_reason or "move failed", live_item=match)
         return []
 
-    matched_id = match.get("id") or match.get("hash")
-    if matched_id:
-        bucket["matched_ids"].add(matched_id)
     _state["pending"].pop(key, None)
     _state["completed"].add(key)
     if matched_id:
@@ -1440,13 +1440,10 @@ def _build_update_destination(dest_root, title_id, title_name, version, src_path
 
 
 def _get_import_extension(src_path):
-    name = os.path.basename(str(src_path or ""))
-    lowered = name.lower()
-    for extension in ALLOWED_EXTENSIONS:
-        if lowered.endswith(f".{extension}.hdf"):
-            # Some wrapped usenet releases keep the real content extension before .hdf.
-            return extension
-    return os.path.splitext(name)[1].lstrip(".")
+    extension = get_supported_content_extension(src_path)
+    if extension:
+        return extension
+    return os.path.splitext(os.path.basename(str(src_path or "")))[1].lstrip(".")
 
 
 def _cleanup_download_path(src_path, dest_root):
@@ -1475,15 +1472,13 @@ def _cleanup_download_path(src_path, dest_root):
 
 
 def _is_wrapped_import_path(path):
-    lowered = str(path or "").lower()
-    return any(lowered.endswith(f".{ext}.hdf") for ext in ALLOWED_EXTENSIONS)
+    return is_wrapped_content_path(path)
 
 
 def _is_importable_download_file(path):
     if not path or not os.path.isfile(path):
         return False
-    extension = os.path.splitext(path)[1].lstrip(".").lower()
-    return extension in ALLOWED_EXTENSIONS or _is_wrapped_import_path(path)
+    return is_supported_content_path(path)
 
 
 def _iter_importable_download_files(src_path):
@@ -1509,6 +1504,35 @@ def _build_generic_import_destination(dest_root, src_path):
     if normalized_extension and lowered.endswith(f".{normalized_extension}.hdf"):
         basename = basename[:-4]
     return _ensure_unique_path(os.path.join(dest_root, basename))
+
+
+def _move_generic_importable_files(src_path, dest_root, excluded_paths=None):
+    excluded = {
+        os.path.normcase(os.path.normpath(path))
+        for path in (excluded_paths or [])
+        if path
+    }
+    importable_paths = [
+        path for path in _iter_importable_download_files(src_path)
+        if os.path.normcase(os.path.normpath(path)) not in excluded
+    ]
+    if not importable_paths:
+        logger.warning("No importable files found in completed download: %s", src_path)
+        return None, "no importable files found"
+
+    moved_paths = []
+    try:
+        for import_path in importable_paths:
+            dest_path = _build_generic_import_destination(dest_root, import_path)
+            shutil.move(import_path, dest_path)
+            dest_path = _normalize_imported_wrapped_files(dest_path)
+            moved_paths.append(dest_path)
+        _cleanup_download_path(src_path, dest_root)
+        logger.info("Moved download to library: %s", ", ".join(moved_paths))
+        return (moved_paths[0] if len(moved_paths) == 1 else moved_paths), None
+    except Exception as e:
+        logger.warning("Failed to move download %s: %s", src_path, e)
+        return None, str(e)
 
 
 def _normalize_imported_wrapped_files(dest_path):
@@ -1571,10 +1595,27 @@ def _move_completed_with_reason(item, update_info=None):
         title_name = update_info.get("title_name") or update_info.get("expected_name")
         update_path, actual_version = _select_completed_update_candidate(src_path)
         if not update_path or not actual_version:
+            moved_result, move_reason = _move_generic_importable_files(src_path, dest_root)
+            if moved_result:
+                logger.info(
+                    "Imported completed download for %s without update payload; kept generic files from %s.",
+                    title_id,
+                    src_path,
+                )
+                return moved_result, None
             logger.warning("No update file found for %s v%s in %s", title_id, requested_version, src_path)
             return None, "no update file found"
         highest_owned = _get_highest_owned_update_version(title_id)
         if actual_version <= highest_owned:
+            moved_result, move_reason = _move_generic_importable_files(src_path, dest_root, excluded_paths=[update_path])
+            if moved_result:
+                logger.info(
+                    "Skipped stale update %s v%s and imported remaining files from %s.",
+                    title_id,
+                    actual_version,
+                    src_path,
+                )
+                return moved_result, None
             return None, f"downloaded v{actual_version} is not newer than owned v{highest_owned}"
         if requested_version and int(actual_version) != int(requested_version):
             logger.info(
@@ -1599,23 +1640,7 @@ def _move_completed_with_reason(item, update_info=None):
 
     if os.path.abspath(os.path.dirname(src_path)) == os.path.abspath(dest_root):
         return _normalize_imported_wrapped_files(src_path), None
-    importable_paths = _iter_importable_download_files(src_path)
-    if not importable_paths:
-        logger.warning("No importable files found in completed download: %s", src_path)
-        return None, "no importable files found"
-    moved_paths = []
-    try:
-        for import_path in importable_paths:
-            dest_path = _build_generic_import_destination(dest_root, import_path)
-            shutil.move(import_path, dest_path)
-            dest_path = _normalize_imported_wrapped_files(dest_path)
-            moved_paths.append(dest_path)
-        _cleanup_download_path(src_path, dest_root)
-        logger.info("Moved download to library: %s", ", ".join(moved_paths))
-        return (moved_paths[0] if len(moved_paths) == 1 else moved_paths), None
-    except Exception as e:
-        logger.warning("Failed to move download %s: %s", src_path, e)
-        return None, str(e)
+    return _move_generic_importable_files(src_path, dest_root)
 
 
 def _move_completed(item, update_info=None):

--- a/app/file_watcher.py
+++ b/app/file_watcher.py
@@ -125,7 +125,10 @@ class Handler(FileSystemEventHandler):
         if source_event.is_directory:
             return
 
-        if not any(source_event.src_path.endswith(ext) or source_event.dest_path.endswith(ext) for ext in ALLOWED_EXTENSIONS):
+        if not (
+            is_supported_content_path(source_event.src_path)
+            or is_supported_content_path(source_event.dest_path)
+        ):
             return
 
         library_event = SimpleNamespace(
@@ -135,7 +138,7 @@ class Handler(FileSystemEventHandler):
             dest_path=source_event.dest_path,
         )
 
-        if library_event.type == 'moved' and not any(library_event.dest_path.endswith(ext) for ext in ALLOWED_EXTENSIONS):
+        if library_event.type == 'moved' and not is_supported_content_path(library_event.dest_path):
             library_event.type = 'deleted'
 
         if library_event.type == 'deleted':

--- a/app/library.py
+++ b/app/library.py
@@ -121,11 +121,7 @@ def _iter_library_files(library_path):
     """Yield supported files under a library path without building a full list in memory."""
     for root, _, filenames in os.walk(library_path):
         for filename in filenames:
-            try:
-                extension = filename.rsplit('.', 1)[-1].lower()
-            except Exception:
-                extension = ''
-            if extension in ALLOWED_EXTENSIONS:
+            if is_supported_content_path(filename):
                 yield os.path.join(root, filename)
 
 def add_library_complete(app, watcher, path):
@@ -1976,8 +1972,7 @@ def _cleanup_import_staging_roots(paths):
             continue
         for dirpath, _, filenames in os.walk(root, topdown=False):
             for filename in filenames:
-                extension = filename.rsplit('.', 1)[-1].lower() if '.' in filename else ''
-                if extension in ALLOWED_EXTENSIONS:
+                if is_supported_content_path(filename):
                     continue
                 try:
                     os.remove(os.path.join(dirpath, filename))

--- a/app/titles.py
+++ b/app/titles.py
@@ -744,7 +744,7 @@ def getDirsAndFiles(path):
             dirs, files = getDirsAndFiles(fullPath)
             allDirs += dirs
             allFiles += files
-        elif fullPath.split('.')[-1] in ALLOWED_EXTENSIONS:
+        elif is_supported_content_path(fullPath):
             allFiles.append(fullPath)
     return allDirs, allFiles
 

--- a/app/utils.py
+++ b/app/utils.py
@@ -122,6 +122,33 @@ def allowed_file(filename):
     return '.' in filename and \
            filename.rsplit('.', 1)[1].lower() in ['keys', 'txt']
 
+
+def get_supported_content_extension(path):
+    name = os.path.basename(str(path or ""))
+    lowered = name.lower()
+    if not lowered:
+        return None
+    try:
+        from app.constants import ALLOWED_EXTENSIONS
+    except Exception:
+        return None
+    for extension in ALLOWED_EXTENSIONS:
+        suffix = f".{extension}"
+        if lowered.endswith(suffix) or lowered.endswith(f"{suffix}.hdf"):
+            return extension
+    return None
+
+
+def is_wrapped_content_path(path):
+    extension = get_supported_content_extension(path)
+    if not extension:
+        return False
+    return str(path or "").lower().endswith(f".{extension}.hdf")
+
+
+def is_supported_content_path(path):
+    return get_supported_content_extension(path) is not None
+
 def safe_write_json(path, data, **dump_kwargs):
     with _json_write_lock:
         dirpath = os.path.dirname(path) or "."

--- a/tests/test_download_clients.py
+++ b/tests/test_download_clients.py
@@ -558,8 +558,8 @@ class QueueRoutingTests(unittest.TestCase):
                 "version": 655360,
                 "hash": "nzo456",
                 "id": "nzo456",
-                "expected_name": "Game Boy Advance Nintendo Switch Online Update v3.2.0 INTERNAL NSW-SUXXORS",
-                "title_name": "Game Boy Advance Nintendo Switch Online",
+                "expected_name": "Example Title Update v3.2.0 INTERNAL NSW-GRP",
+                "title_name": "Example Title",
                 "protocol": "usenet",
                 "client_type": "sabnzbd",
                 "state": "queued",
@@ -594,7 +594,7 @@ class QueueRoutingTests(unittest.TestCase):
 
         self.assertEqual(
             state["pending"][0]["label"],
-            "Game Boy Advance Nintendo Switch Online Update v3.2.0 INTERNAL NSW-SUXXORS",
+            "Example Title Update v3.2.0 INTERNAL NSW-GRP",
         )
 
     @patch("app.downloads.client.add_nzb")
@@ -1409,6 +1409,50 @@ class ManagedCompletionStateTests(unittest.TestCase):
         self.assertIsNone(moved_path)
         self.assertEqual(reason, "downloaded v983040 is not newer than owned v1376256")
         move_mock.assert_not_called()
+
+    @patch("app.downloads.manager._cleanup_download_path")
+    @patch("app.downloads.manager._normalize_imported_wrapped_files", side_effect=lambda path: path[:-4] if path.endswith(".hdf") else path)
+    @patch("app.downloads.manager._build_generic_import_destination", side_effect=lambda dest_root, src_path: os.path.join(dest_root, os.path.basename(src_path)))
+    @patch("app.downloads.manager.shutil.move")
+    @patch(
+        "app.downloads.manager._iter_importable_download_files",
+        return_value=[
+            "C:\\tests\\completed\\sample_v983040.nsp.hdf",
+            "C:\\tests\\completed\\sample-dlc.nsp.hdf",
+        ],
+    )
+    @patch("app.downloads.manager.get_libraries_path", return_value=["X:\\library"])
+    @patch("app.downloads.manager.os.path.exists", return_value=True)
+    @patch("app.downloads.manager._get_highest_owned_update_version", return_value=1376256)
+    @patch("app.downloads.manager._select_completed_update_candidate", return_value=("C:\\tests\\completed\\sample_v983040.nsp.hdf", 983040))
+    def test_move_completed_imports_other_files_when_update_is_not_newer(
+        self,
+        select_candidate_mock,
+        highest_owned_mock,
+        exists_mock,
+        get_libraries_path_mock,
+        importable_files_mock,
+        move_mock,
+        build_dest_mock,
+        normalize_mock,
+        cleanup_mock,
+    ):
+        moved_path, reason = _move_completed_with_reason(
+            {"path": "C:\\tests\\completed\\Sample Release"},
+            {
+                "title_id": "0100C62011050000",
+                "title_name": "Sample Game",
+                "version": 1376256,
+            },
+        )
+
+        self.assertIsNone(reason)
+        self.assertEqual(moved_path, "X:\\library\\sample-dlc.nsp")
+        move_mock.assert_called_once_with(
+            "C:\\tests\\completed\\sample-dlc.nsp.hdf",
+            "X:\\library\\sample-dlc.nsp.hdf",
+        )
+        cleanup_mock.assert_called_once_with("C:\\tests\\completed\\Sample Release", "X:\\library")
 
     @patch("app.downloads.manager.list_completed_downloads")
     @patch("app.downloads.manager._get_completed_poll_targets")

--- a/tests/test_file_watcher.py
+++ b/tests/test_file_watcher.py
@@ -1,0 +1,45 @@
+import unittest
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from app.file_watcher import Handler
+
+
+class FileWatcherTests(unittest.TestCase):
+    @patch("app.file_watcher.os.path.getsize", return_value=10)
+    def test_collect_event_tracks_wrapped_supported_file(self, getsize_mock):
+        callback_events = []
+        handler = Handler(callback_events.extend, stability_duration=5)
+        handler.debounced_check_final = lambda: None
+        with patch.object(handler, "_check_file_stability") as check_mock:
+            handler.collect_event(
+                SimpleNamespace(
+                    is_directory=False,
+                    event_type="created",
+                    src_path="X:\\library\\Example DLC.nsp.hdf",
+                    dest_path="X:\\library\\Example DLC.nsp.hdf",
+                ),
+                "X:\\library",
+            )
+
+        self.assertIn("X:\\library\\Example DLC.nsp.hdf", handler.tracked_files)
+        check_mock.assert_called_once()
+
+    def test_collect_event_treats_wrapped_move_to_unsupported_path_as_delete(self):
+        callback_events = []
+        handler = Handler(callback_events.extend, stability_duration=5)
+        handler.debounced_check_final = lambda: None
+        with patch.object(handler, "_check_file_stability") as check_mock:
+            handler.collect_event(
+                SimpleNamespace(
+                    is_directory=False,
+                    event_type="moved",
+                    src_path="X:\\library\\Example DLC.nsp.hdf",
+                    dest_path="X:\\library\\Example DLC.txt",
+                ),
+                "X:\\library",
+            )
+
+        self.assertEqual(len(callback_events), 1)
+        self.assertEqual(callback_events[0].type, "deleted")
+        check_mock.assert_called_once()

--- a/tests/test_library_helpers.py
+++ b/tests/test_library_helpers.py
@@ -21,6 +21,7 @@ try:
         _delete_target_apps,
         _finalize_staged_conversion_output,
         _format_nsz_command,
+        _iter_library_files,
         _pending_cleanup_roots,
         _pending_organize_paths,
         _sanitize_component,
@@ -30,6 +31,7 @@ try:
         enqueue_cleanup_roots,
         enqueue_organize_paths,
     )
+    from app.titles import getDirsAndFiles
 except ModuleNotFoundError as exc:
     _IMPORT_ERROR = exc
 
@@ -221,7 +223,7 @@ class LibraryHelperTests(unittest.TestCase):
         rmdir_mock,
     ):
         walk_mock.return_value = [
-            ("X:\\fixture-root\\Example Release NSW-GRP\\subdir", [], ["keep.nsp", "proof.nfo"]),
+            ("X:\\fixture-root\\Example Release NSW-GRP\\subdir", [], ["keep.nsp", "keep-dlc.nsp.hdf", "proof.nfo"]),
             ("X:\\fixture-root\\Example Release NSW-GRP", ["subdir"], ["notes.txt"]),
         ]
 
@@ -234,6 +236,39 @@ class LibraryHelperTests(unittest.TestCase):
                 "X:\\fixture-root\\Example Release NSW-GRP\\notes.txt",
             ],
         )
+
+    def test_iter_library_files_includes_wrapped_supported_files(self):
+        tmp_root = self._make_test_temp_root("iter_library_files")
+        os.makedirs(os.path.join(tmp_root, "subdir"), exist_ok=True)
+        with open(os.path.join(tmp_root, "base.nsp.hdf"), "w", encoding="utf-8") as handle:
+            handle.write("wrapped")
+        with open(os.path.join(tmp_root, "subdir", "update.nsz"), "w", encoding="utf-8") as handle:
+            handle.write("native")
+        with open(os.path.join(tmp_root, "subdir", "notes.txt"), "w", encoding="utf-8") as handle:
+            handle.write("ignored")
+
+        result = sorted(os.path.relpath(path, tmp_root) for path in _iter_library_files(tmp_root))
+
+        self.assertEqual(
+            result,
+            [
+                "base.nsp.hdf",
+                os.path.join("subdir", "update.nsz"),
+            ],
+        )
+
+    def test_get_dirs_and_files_includes_wrapped_supported_files(self):
+        tmp_root = self._make_test_temp_root("get_dirs_and_files")
+        os.makedirs(os.path.join(tmp_root, "nested"), exist_ok=True)
+        with open(os.path.join(tmp_root, "nested", "dlc.nsp.hdf"), "w", encoding="utf-8") as handle:
+            handle.write("wrapped")
+        with open(os.path.join(tmp_root, "nested", "proof.nfo"), "w", encoding="utf-8") as handle:
+            handle.write("ignored")
+
+        dirs, files = getDirsAndFiles(tmp_root)
+
+        self.assertIn(os.path.join(tmp_root, "nested"), dirs)
+        self.assertEqual(files, [os.path.join(tmp_root, "nested", "dlc.nsp.hdf")])
 
     @patch("app.library.delete_file_by_filepath")
     @patch("app.library.os.remove")


### PR DESCRIPTION
## Summary
- add wrapped content file handling in the download and library flow
- update related watcher/title logic to recognize the wrapped content pathing correctly
- extend tests covering download clients, file watcher behavior, and library helpers

## Notes
- branch diff includes changes in `app/downloads/manager.py`, `app/file_watcher.py`, `app/library.py`, `app/titles.py`, and `app/utils.py`
- test updates are included in `tests/test_download_clients.py`, `tests/test_file_watcher.py`, and `tests/test_library_helpers.py`
- I did not run the test suite in this session