### PR TITLE
fix: restore queue state from downloader

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,6 +44,7 @@ Tests use the standard library `unittest` framework with `unittest.mock.patch`. 
 
 ## Commit & Pull Request Guidelines
 Match the existing history: short imperative Conventional Commit style subjects. Keep commits scoped to one change. If an issue number is given, include it in the commit msg. PRs should describe the user-visible impact, note any config or migration implications, link related issues, and include screenshots for UI/template changes. When a branch touches downloads or library management, mention protocol/client support, queue behavior, cleanup actions, and the focused unittest commands that cover the change.
+Use non-interactive Git editor flows by default. Prefer commands such as `git commit --no-edit` or explicitly setting a no-op editor instead of opening an interactive editor during rebases, merges, or other automated Git steps.
 
 ## Security & Configuration Tips
 Do not commit secrets, `keys.txt`, or real API credentials. Prefer `AEROFOIL_*` environment variables over legacy `OWNFOIL_*` names. For production, set a strong `AEROFOIL_SECRET_KEY` and validate proxy settings before enabling trusted forwarded headers.

--- a/app/downloads/manager.py
+++ b/app/downloads/manager.py
@@ -7,7 +7,7 @@ import time
 import unicodedata
 
 from app import titles as titles_lib
-from app.constants import ALLOWED_EXTENSIONS, APP_TYPE_DLC, APP_TYPE_UPD
+from app.constants import ALLOWED_EXTENSIONS, APP_TYPE_BASE, APP_TYPE_DLC, APP_TYPE_UPD
 from app.db import get_all_title_apps, get_all_titles, get_libraries_path
 from app.downloads.client import (
     TORRENT_CLIENT_TYPES,
@@ -30,6 +30,7 @@ _state = {
     "last_run": 0.0,
     "pending": {},  # key -> info
     "completed": set(),
+    "completed_identities": set(),
 }
 _state_loaded = False
 
@@ -981,6 +982,15 @@ def _get_pending_identity(info):
     return None
 
 
+def _get_completed_identities_locked():
+    identities = _state.get("completed_identities")
+    if isinstance(identities, set):
+        return identities
+    identities = set(identities or [])
+    _state["completed_identities"] = identities
+    return identities
+
+
 def _build_restored_pending_key(item):
     protocol = str((item or {}).get("protocol") or "").strip().lower() or "download"
     client_type = str((item or {}).get("client_type") or "").strip().lower() or "client"
@@ -1106,9 +1116,12 @@ def _infer_pending_info_from_queue_item(item):
         info["title_id"] = inferred.get("title_id")
         info["app_id"] = inferred.get("app_id")
         info["app_type"] = inferred.get("app_type")
-        info["version"] = inferred.get("version")
+        if inferred.get("app_type") != APP_TYPE_BASE:
+            info["version"] = inferred.get("version")
         info["title_name"] = inferred.get("title_name") or info["title_name"]
     return info
+
+
 def _restore_pending_from_active(downloads):
     _ensure_downloads_state_loaded()
     poll_targets = _get_completed_poll_targets(downloads)
@@ -1121,20 +1134,23 @@ def _restore_pending_from_active(downloads):
             queued_items.extend(list_active_downloads(protocol, client_cfg))
         except Exception as exc:
             logger.warning("Failed to restore pending %s queue state: %s", protocol, exc)
-        try:
-            queued_items.extend(list_completed_downloads(protocol, client_cfg))
-        except Exception as exc:
-            logger.warning("Failed to restore completed %s queue state: %s", protocol, exc)
+        if protocol == "usenet":
+            try:
+                queued_items.extend(list_completed_downloads(protocol, client_cfg))
+            except Exception as exc:
+                logger.warning("Failed to restore completed %s queue state: %s", protocol, exc)
 
     if not queued_items:
         return 0
 
     restored = 0
     with _state_lock:
+        completed_identities = _get_completed_identities_locked()
         known_identities = {
             identity for identity in (_get_pending_identity(info) for info in _state["pending"].values())
             if identity
         }
+        known_identities.update(completed_identities)
         for item in queued_items:
             identity = _get_pending_identity(item)
             if identity and identity in known_identities:
@@ -1197,12 +1213,13 @@ def _resolve_completed_update_info(info, completed_item):
         return info
     title_id = str(info.get("title_id") or "").strip()
     version = info.get("version")
-    if title_id and version is not None:
+    if info.get("app_type") != APP_TYPE_BASE and title_id and version is not None:
         return info
     inferred = _infer_update_info_from_completed_item(completed_item)
     if not inferred:
         return info
     merged = dict(info)
+    merged["app_type"] = APP_TYPE_UPD
     merged["title_id"] = inferred.get("title_id")
     merged["title_name"] = inferred.get("title_name") or merged.get("title_name")
     merged["version"] = inferred.get("version")
@@ -1412,6 +1429,9 @@ def _process_tracked_completed_item_locked(key, info, bucket):
 
     _state["pending"].pop(key, None)
     _state["completed"].add(key)
+    identity = _get_pending_identity(match) or _get_pending_identity(info)
+    if identity:
+        _get_completed_identities_locked().add(identity)
     if matched_id:
         ok, message = remove_completed_download(
             str(info.get("protocol") or "").strip().lower(),
@@ -1693,6 +1713,7 @@ def _move_completed_with_reason(item, update_info=None):
 
     if (
         update_info
+        and update_info.get("app_type") != APP_TYPE_BASE
         and update_info.get("title_id")
         and update_info.get("version")
         and str(update_info.get("title_id")).strip().lower() != "manual"

--- a/tests/test_download_clients.py
+++ b/tests/test_download_clients.py
@@ -561,6 +561,99 @@ class QueueRoutingTests(unittest.TestCase):
         self.assertEqual(state["pending"][0]["state"], "completed")
         self.assertEqual(state["pending"][0]["label"], "Example DLC Release")
 
+    @patch("app.downloads.manager._infer_pending_info_from_queue_item")
+    @patch("app.downloads.manager.list_completed_downloads")
+    @patch("app.downloads.manager.list_active_downloads", return_value=[])
+    @patch("app.downloads.manager._get_completed_poll_targets")
+    @patch("app.downloads.manager.load_settings")
+    @patch("app.downloads.manager._state_lock")
+    @patch("app.downloads.manager._state", {
+        "running": False,
+        "last_run": 123.0,
+        "pending": {},
+        "completed": set(),
+        "completed_identities": set(),
+    })
+    def test_get_downloads_state_does_not_restore_pending_items_from_completed_torrent_queue(
+        self,
+        _state_lock_mock,
+        load_settings_mock,
+        poll_targets_mock,
+        list_active_mock,
+        list_completed_mock,
+        infer_pending_mock,
+    ):
+        load_settings_mock.return_value = {
+            "downloads": {
+                "torrent_client": {
+                    "type": "qbittorrent",
+                    "url": "http://torrent.local",
+                    "category": "aerofoil",
+                }
+            }
+        }
+        poll_targets_mock.return_value = [("torrent", {"type": "qbittorrent", "category": "aerofoil"})]
+        list_completed_mock.return_value = [{
+            "id": "ABC123",
+            "hash": "ABC123",
+            "protocol": "torrent",
+            "client_type": "qbittorrent",
+            "name": "Example Release NSW-GRP",
+            "path": "X:\\fixture-root\\incoming\\Example Release NSW-GRP",
+        }]
+
+        state = get_downloads_state()
+
+        self.assertEqual(state["pending"], [])
+        infer_pending_mock.assert_not_called()
+
+    @patch("app.downloads.manager._infer_pending_info_from_queue_item")
+    @patch("app.downloads.manager.list_completed_downloads")
+    @patch("app.downloads.manager.list_active_downloads", return_value=[])
+    @patch("app.downloads.manager._get_completed_poll_targets")
+    @patch("app.downloads.manager.load_settings")
+    @patch("app.downloads.manager._state_lock")
+    @patch("app.downloads.manager._state", {
+        "running": False,
+        "last_run": 123.0,
+        "pending": {},
+        "completed": {"0100000000010000:123"},
+        "completed_identities": {("usenet", "sabnzbd", "nzo123")},
+    })
+    def test_get_downloads_state_skips_restoring_completed_items_already_seen_by_identity(
+        self,
+        _state_lock_mock,
+        load_settings_mock,
+        poll_targets_mock,
+        list_active_mock,
+        list_completed_mock,
+        infer_pending_mock,
+    ):
+        load_settings_mock.return_value = {
+            "downloads": {
+                "usenet_client": {
+                    "type": "sabnzbd",
+                    "url": "http://sab.local",
+                    "api_key": "secret",
+                    "category": "aerofoil",
+                }
+            }
+        }
+        poll_targets_mock.return_value = [("usenet", {"type": "sabnzbd", "category": "aerofoil"})]
+        list_completed_mock.return_value = [{
+            "id": "nzo123",
+            "hash": "nzo123",
+            "protocol": "usenet",
+            "client_type": "sabnzbd",
+            "name": "Example Release NSW-GRP",
+            "path": "X:\\fixture-root\\incoming\\Example Release NSW-GRP",
+        }]
+
+        state = get_downloads_state()
+
+        self.assertEqual(state["pending"], [])
+        infer_pending_mock.assert_not_called()
+
     @patch("app.downloads.manager.list_completed_downloads")
     @patch("app.downloads.manager.list_active_downloads", return_value=[])
     @patch("app.downloads.manager._get_completed_poll_targets")
@@ -696,6 +789,30 @@ class QueueRoutingTests(unittest.TestCase):
         self.assertEqual(info["app_type"], "DLC")
         self.assertEqual(info["version"], 0)
         self.assertEqual(info["expected_name"], "Example Title DLC Pack")
+
+    @patch("app.downloads.manager._infer_content_info_from_completed_item")
+    def test_infer_pending_info_from_queue_item_does_not_copy_base_version(self, infer_content_mock):
+        infer_content_mock.return_value = {
+            "title_id": "0100000000010000",
+            "app_id": "0100000000010000",
+            "app_type": "BASE",
+            "title_name": "Example Title",
+            "version": 65536,
+        }
+
+        info = _infer_pending_info_from_queue_item({
+            "id": "abc123",
+            "hash": "abc123",
+            "protocol": "usenet",
+            "client_type": "sabnzbd",
+            "name": "Example Title BASE",
+            "path": "X:\\fixture-root\\incoming\\Example Title BASE",
+        })
+
+        self.assertEqual(info["title_id"], "0100000000010000")
+        self.assertEqual(info["app_type"], "BASE")
+        self.assertIsNone(info["version"])
+        self.assertEqual(info["expected_name"], "Example Title BASE")
 
     @patch("app.downloads.client.add_nzb")
     def test_queue_download_forwards_update_selection_to_usenet_client(self, add_nzb_mock):
@@ -1217,7 +1334,7 @@ class CompletedAdoptionTests(unittest.TestCase):
 
         _check_completed({})
 
-        move_completed_mock.assert_called_once()
+        move_completed_mock.assert_not_called()
         remove_completed_mock.assert_not_called()
         enqueue_paths_mock.assert_not_called()
         enqueue_cleanup_roots_mock.assert_not_called()
@@ -1448,6 +1565,32 @@ class CompletedAdoptionTests(unittest.TestCase):
 
 
 class ManagedCompletionStateTests(unittest.TestCase):
+    @patch("app.downloads.manager._select_completed_update_candidate")
+    @patch("app.downloads.manager._move_generic_importable_files", return_value=("X:\\library\\Example Title [BASE].nsp", None))
+    @patch("app.downloads.manager.get_libraries_path", return_value=["X:\\library"])
+    @patch("app.downloads.manager.os.path.exists", return_value=True)
+    def test_move_completed_treats_non_update_metadata_as_generic_import(
+        self,
+        exists_mock,
+        get_libraries_path_mock,
+        move_generic_mock,
+        select_candidate_mock,
+    ):
+        moved_path, reason = _move_completed_with_reason(
+            {"path": "C:\\tests\\completed\\Example Title BASE"},
+            {
+                "title_id": "0100000000010000",
+                "title_name": "Example Title",
+                "app_type": "BASE",
+                "version": 65536,
+            },
+        )
+
+        self.assertEqual(moved_path, "X:\\library\\Example Title [BASE].nsp")
+        self.assertIsNone(reason)
+        move_generic_mock.assert_called_once_with("C:\\tests\\completed\\Example Title BASE", "X:\\library")
+        select_candidate_mock.assert_not_called()
+
     @patch("app.downloads.manager._cleanup_download_path")
     @patch("app.downloads.manager.shutil.move")
     @patch("app.downloads.manager.os.makedirs")


### PR DESCRIPTION
## Summary
- restore pending download state from active downloader queues after restarts
- restore completed downloader history only for Usenet so completed torrents are not adopted and removed unexpectedly
- prevent restored `BASE` packages from being routed through update-only import handling
- dedupe restored completed items by downloader identity so already-processed history entries are not resurrected
- add regression coverage for completed restore, base-package metadata handling, and identity dedupe paths

## Notes
- branch diff includes changes in `app/downloads/manager.py`, `tests/test_download_clients.py`, and `AGENTS.md`
- PR now includes follow-up fixes for review findings around completed queue restore behavior

## Verification
- `python -m unittest tests.test_download_clients`