### PR TITLE
feat: refresh app ui layout

### DIFF
--- a/app/static/style.css
+++ b/app/static/style.css
@@ -1,3 +1,8 @@
+:root {
+    --aerofoil-card-radius: 16px;
+    --aerofoil-card-radius-tight: 14px;
+}
+
 /* body {
     font-family: Arial, sans-serif;
     background-color: #2a3a4f;
@@ -273,7 +278,7 @@
     padding: 10px 10px 64px;
     height: 120px;
     overflow: hidden;
-    border-radius: 0 0 8px 8px;
+    border-radius: 0 0 var(--aerofoil-card-radius) var(--aerofoil-card-radius);
     border-top: 1px solid #d5d5d5bd;
     top: unset;
 }
@@ -283,15 +288,19 @@
     margin-right: 5px;
 }
 
-.card {
-    border-radius: 8px !important;
-    /* linear-gradient(to top, rgba(0, 0, 0, 0.7), transparent 50%), */
+.card,
+.aerofoil-card {
+    border: 1px solid var(--bs-card-border-color, rgba(255, 255, 255, 0.12));
+    border-radius: var(--aerofoil-card-radius) !important;
+    background-color: var(--bs-card-bg, var(--bs-body-bg));
+    box-shadow: 0 0.35rem 0.9rem rgba(0, 0, 0, 0.08);
+    overflow: hidden;
 }
 
 .card-img {
     mask-image: linear-gradient(to top, rgba(7, 0, 91, 0.71), #001233ed);
-    border-bottom-right-radius: 8px;
-    border-bottom-left-radius: 8px;
+    border-bottom-right-radius: var(--aerofoil-card-radius);
+    border-bottom-left-radius: var(--aerofoil-card-radius);
 }
 
 /* Card view: keep overlays inside card bounds */
@@ -488,6 +497,23 @@ p.game-description {
 
 .discover-scroll-right {
     right: 0;
+}
+
+@media (min-width: 992px) and (max-width: 1078px) {
+    .navbar .navbar-nav .nav-link {
+        white-space: nowrap;
+        padding-right: 0.5rem;
+        padding-left: 0.5rem;
+        font-size: 0.95rem;
+    }
+
+    .navbar-brand-banner {
+        max-width: 170px;
+    }
+
+    #navbarNav > .navbar-nav {
+        min-width: 0;
+    }
 }
 
 .discover-tile {
@@ -833,8 +859,70 @@ p.game-description {
     }
 }
 
+.card > .card-body,
+.card > .card-header,
+.card > .card-footer,
+.aerofoil-card > .card-body,
+.aerofoil-card > .card-header,
+.aerofoil-card > .card-footer {
+    border-radius: inherit;
+}
+
+.card > .card-body:last-child,
+.card > .card-footer:last-child,
+.aerofoil-card > .card-body:last-child,
+.aerofoil-card > .card-footer:last-child {
+    border-bottom-left-radius: inherit;
+    border-bottom-right-radius: inherit;
+}
+
+.card > .card-header:first-child,
+.aerofoil-card > .card-header:first-child {
+    border-top-left-radius: inherit;
+    border-top-right-radius: inherit;
+}
+
+.aerofoil-card {
+    background-color: var(--bs-body-bg);
+}
+
+.aerofoil-card-soft {
+    background: var(--bs-tertiary-bg);
+}
+
+.aerofoil-card-tight {
+    border-radius: var(--aerofoil-card-radius-tight) !important;
+}
+
 .settings-section {
     animation: fadeIn 0.2s ease-in;
+}
+
+.settings-panel {
+    margin-bottom: 1.5rem;
+}
+
+.settings-panel .card-body {
+    padding: 1.25rem 1.25rem 1.1rem;
+}
+
+.settings-panel-header {
+    margin-bottom: 1rem;
+}
+
+.settings-panel-header .card-title {
+    margin-bottom: 0.2rem;
+}
+
+.settings-panel-actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.75rem;
+    align-items: center;
+}
+
+.settings-option-stack > * + * {
+    margin-top: 0.9rem;
 }
 
 @keyframes fadeIn {

--- a/app/templates/activity.html
+++ b/app/templates/activity.html
@@ -1,7 +1,4 @@
-{% extends 'base.html' %}
-
-{% block content %}
-{% include 'nav.html' %}
+{% extends 'base.html' %} {% block content %} {% include 'nav.html' %}
 
 <style>
     :root {
@@ -69,9 +66,8 @@
         height: 100%;
         display: flex;
         flex-direction: column;
-        gap: 0.75rem;
-        padding-top: 0.75rem;
-        padding-bottom: 0.75rem;
+        gap: 0.85rem;
+        padding: 0.75rem 1rem 1rem;
     }
 
     .activity-pane-wrap {
@@ -82,13 +78,13 @@
 
     #activityNav .nav-link {
         color: rgba(255, 255, 255, 0.75);
-        padding: 0.75rem 1rem;
-        border-radius: 0.375rem;
+        padding: 0.8rem 1rem;
+        border-radius: 0.5rem;
         margin-bottom: 0.25rem;
         transition: all 0.2s ease;
         display: flex;
-        align-items: center;
-        gap: 0.45rem;
+        align-items: flex-start;
+        gap: 0.7rem;
     }
 
     #activityNav .nav-link:hover {
@@ -106,25 +102,53 @@
         width: 16px;
         text-align: center;
         flex-shrink: 0;
+        margin-top: 0.1rem;
+        margin-right: 0.5rem;
+    }
+
+    .activity-nav-copy {
+        display: flex;
+        flex-direction: column;
+        gap: 0.15rem;
+        min-width: 0;
+    }
+
+    .activity-nav-title {
+        line-height: 1.2;
+    }
+
+    .activity-nav-subtitle {
+        color: var(--activity-muted);
+        font-size: 0.78rem;
+        line-height: 1.25;
     }
 
     .activity-header {
         border: 1px solid var(--activity-border);
-        border-radius: 16px;
+        border-radius: var(--aerofoil-card-radius);
         padding: 1rem 1.1rem;
         background: var(--activity-surface-2);
+        box-shadow: 0 0.35rem 0.9rem rgba(0, 0, 0, 0.08);
     }
 
     .activity-subtitle {
         color: var(--activity-muted);
     }
 
+    .activity-page-meta {
+        display: flex;
+        flex-wrap: wrap;
+        align-items: center;
+        gap: 0.5rem;
+    }
+
     .activity-kpi {
         border: 1px solid var(--activity-border);
-        border-radius: 14px;
+        border-radius: var(--aerofoil-card-radius-tight);
         background: var(--activity-surface-2);
         padding: 0.8rem 1rem;
         min-height: 82px;
+        box-shadow: 0 0.35rem 0.9rem rgba(0, 0, 0, 0.06);
     }
 
     .activity-kpi-label {
@@ -143,9 +167,18 @@
 
     .activity-section {
         border: 1px solid var(--activity-border);
-        border-radius: 16px;
+        border-radius: var(--aerofoil-card-radius);
         background: var(--activity-surface-1);
         padding: 1rem;
+        box-shadow: 0 0.35rem 0.9rem rgba(0, 0, 0, 0.08);
+    }
+
+    .activity-card {
+        border: 0;
+        border-radius: 0 !important;
+        background: transparent;
+        box-shadow: none;
+        overflow: visible;
     }
 
     .activity-section-head {
@@ -160,12 +193,6 @@
     .activity-section-subtitle {
         color: var(--activity-muted);
         font-size: 0.85rem;
-    }
-
-    .activity-card {
-        border: 0;
-        border-radius: 0;
-        background: transparent;
     }
 
     .activity-card .card-body {
@@ -336,6 +363,7 @@
 
         .activity-header {
             padding: 0.85rem;
+            margin-bottom: 0.85rem;
         }
 
         .activity-section {
@@ -375,7 +403,7 @@
         }
 
         body.activity-sidebar-open::before {
-            content: '';
+            content: "";
             position: fixed;
             top: var(--activity-nav-h);
             left: 0;
@@ -397,8 +425,7 @@
         .activity-main-inner {
             height: auto;
             display: block;
-            padding-top: 0.75rem;
-            padding-bottom: 0.75rem;
+            padding: 0.75rem;
         }
 
         .activity-pane-wrap {
@@ -419,378 +446,825 @@
 
 <div class="activity-body">
     <div class="row g-0 activity-shell-row">
-        <div class="col-md-3 col-lg-2 border-end" id="activitySidebar">
-            <div class="d-flex align-items-center justify-content-between p-3 border-bottom">
-                <h5 class="mb-0">Activity</h5>
-                <button class="btn btn-sm d-md-none" type="button" id="activitySidebarToggle" aria-label="Toggle activity sidebar">
+        <div class="col-md-3 col-xl-2" id="activitySidebar">
+            <div
+                class="d-flex align-items-center justify-content-between p-3 border-bottom"
+            >
+                <div>
+                    <h5 class="mb-0">Activity</h5>
+                    <div class="text-muted small">Audit and monitoring</div>
+                </div>
+                <button
+                    class="btn btn-sm d-md-none"
+                    type="button"
+                    id="activitySidebarToggle"
+                    aria-label="Toggle activity sidebar"
+                >
                     <i class="bi bi-list"></i>
                 </button>
             </div>
             <nav class="nav flex-column p-2" id="activityNav">
-                <a class="nav-link active" href="#" data-section="overview"><i class="bi bi-grid-1x2"></i>Overview</a>
-                <a class="nav-link" href="#" data-section="realtime"><i class="bi bi-activity"></i>Realtime</a>
-                <a class="nav-link" href="#" data-section="access"><i class="bi bi-clock-history"></i>Access History</a>
-                <a class="nav-link" href="#" data-section="blocked"><i class="bi bi-slash-circle"></i>Blocked IPs</a>
-                <a class="nav-link" href="#" data-section="clients"><i class="bi bi-phone"></i>Client History</a>
-                <a class="nav-link" href="#" data-section="lockouts"><i class="bi bi-shield-lock"></i>Lockouts</a>
+                <a class="nav-link active" href="#" data-section="overview"
+                    ><i class="bi bi-grid-1x2"></i
+                    ><span class="activity-nav-copy"
+                        ><span class="activity-nav-title">Overview</span
+                        ><span class="activity-nav-subtitle"
+                            >KPIs and section shortcuts</span
+                        ></span
+                    ></a
+                >
+                <a class="nav-link" href="#" data-section="realtime"
+                    ><i class="bi bi-activity"></i
+                    ><span class="activity-nav-copy"
+                        ><span class="activity-nav-title">Realtime</span
+                        ><span class="activity-nav-subtitle"
+                            >Live sessions and connected clients</span
+                        ></span
+                    ></a
+                >
+                <a class="nav-link" href="#" data-section="access"
+                    ><i class="bi bi-clock-history"></i
+                    ><span class="activity-nav-copy"
+                        ><span class="activity-nav-title">Access History</span
+                        ><span class="activity-nav-subtitle"
+                            >Transfer and shop audit trail</span
+                        ></span
+                    ></a
+                >
+                <a class="nav-link" href="#" data-section="blocked"
+                    ><i class="bi bi-slash-circle"></i
+                    ><span class="activity-nav-copy"
+                        ><span class="activity-nav-title">Blocked IPs</span
+                        ><span class="activity-nav-subtitle"
+                            >Permanent blacklist hits</span
+                        ></span
+                    ></a
+                >
+                <a class="nav-link" href="#" data-section="clients"
+                    ><i class="bi bi-phone"></i
+                    ><span class="activity-nav-copy"
+                        ><span class="activity-nav-title">Client History</span
+                        ><span class="activity-nav-subtitle"
+                            >Devices, user-agents, and metadata</span
+                        ></span
+                    ></a
+                >
+                <a class="nav-link" href="#" data-section="lockouts"
+                    ><i class="bi bi-shield-lock"></i
+                    ><span class="activity-nav-copy"
+                        ><span class="activity-nav-title">Lockouts</span
+                        ><span class="activity-nav-subtitle"
+                            >Failed-login IP lockouts</span
+                        ></span
+                    ></a
+                >
             </nav>
         </div>
 
-        <div class="col-md-9 col-lg-10 activity-main-col">
-            <div class="d-md-none p-3 border-bottom">
-                <button class="btn btn-outline-secondary" type="button" id="activitySidebarToggleMobile" aria-label="Toggle activity sidebar">
-                    <i class="bi bi-list"></i> Sections
-                </button>
-            </div>
-
+        <div class="col-md-9 col-xl-10 activity-main-col">
             <div class="container-fluid activity-main-inner">
                 <div class="activity-header">
-                    <div class="d-flex flex-wrap align-items-start justify-content-between gap-2">
+                    <div
+                        class="d-flex flex-wrap align-items-start justify-content-between gap-2"
+                    >
                         <div>
-                            <h2 class="mb-0">Activity</h2>
-                            <div class="activity-subtitle small">Realtime client and transfer monitoring with persistent audit logs</div>
+                            <h2 class="mb-2">Activity</h2>
+                            <div class="activity-subtitle small">
+                                Realtime monitoring, persistent audit logs, and
+                                access control telemetry in one workspace
+                            </div>
                         </div>
-                        <div class="d-flex flex-wrap align-items-center gap-2">
-                            <span class="badge text-bg-secondary" id="lastRefreshLabel">Last update: -</span>
-                            <span class="badge text-bg-secondary">Live: 2.5s</span>
-                            <span class="badge text-bg-secondary">History: 15s</span>
-                            <button type="button" class="btn btn-outline-primary btn-sm" id="refreshNowBtn">
-                                <i class="bi bi-arrow-clockwise"></i> Refresh now
+                        <div class="activity-page-meta">
+                            <button
+                                class="btn btn-outline-secondary btn-sm d-md-none"
+                                type="button"
+                                id="activitySidebarToggleMobile"
+                                aria-label="Toggle activity sidebar"
+                            >
+                                <i class="bi bi-list"></i> Sections
+                            </button>
+                            <span
+                                class="badge text-bg-secondary"
+                                id="lastRefreshLabel"
+                                >Last update: -</span
+                            >
+                            <span class="badge text-bg-secondary"
+                                >Live: 2.5s</span
+                            >
+                            <span class="badge text-bg-secondary"
+                                >History: 15s</span
+                            >
+                            <button
+                                type="button"
+                                class="btn btn-outline-primary btn-sm"
+                                id="refreshNowBtn"
+                            >
+                                <i class="bi bi-arrow-clockwise"></i> Refresh
+                                now
                             </button>
                         </div>
                     </div>
                 </div>
 
-                <div id="activityAlert" class="alert alert-danger d-none mt-3 mb-0" role="alert"></div>
+                <div
+                    id="activityAlert"
+                    class="alert alert-danger d-none mt-3 mb-0"
+                    role="alert"
+                ></div>
 
                 <div class="activity-pane-wrap">
-                <div class="activity-section-pane" id="section-overview" data-section="overview">
-                    <div class="row g-3">
-                        <div class="col-sm-6 col-xl-3">
-                            <div class="activity-kpi">
-                                <div class="activity-kpi-label">Live Transfers</div>
-                                <div class="activity-kpi-value" id="kpiLiveTransfers">0</div>
+                    <div
+                        class="activity-section-pane"
+                        id="section-overview"
+                        data-section="overview"
+                    >
+                        <div class="row g-3">
+                            <div class="col-sm-6 col-xl-3">
+                                <div class="activity-kpi">
+                                    <div class="activity-kpi-label">
+                                        Live Transfers
+                                    </div>
+                                    <div
+                                        class="activity-kpi-value"
+                                        id="kpiLiveTransfers"
+                                    >
+                                        0
+                                    </div>
+                                </div>
                             </div>
-                        </div>
-                        <div class="col-sm-6 col-xl-3">
-                            <div class="activity-kpi">
-                                <div class="activity-kpi-label">Connected Clients</div>
-                                <div class="activity-kpi-value" id="kpiConnectedClients">0</div>
+                            <div class="col-sm-6 col-xl-3">
+                                <div class="activity-kpi">
+                                    <div class="activity-kpi-label">
+                                        Connected Clients
+                                    </div>
+                                    <div
+                                        class="activity-kpi-value"
+                                        id="kpiConnectedClients"
+                                    >
+                                        0
+                                    </div>
+                                </div>
                             </div>
-                        </div>
-                        <div class="col-sm-6 col-xl-3">
-                            <div class="activity-kpi">
-                                <div class="activity-kpi-label">Access Rows</div>
-                                <div class="activity-kpi-value" id="kpiAccessRows">0</div>
+                            <div class="col-sm-6 col-xl-3">
+                                <div class="activity-kpi">
+                                    <div class="activity-kpi-label">
+                                        Access Rows
+                                    </div>
+                                    <div
+                                        class="activity-kpi-value"
+                                        id="kpiAccessRows"
+                                    >
+                                        0
+                                    </div>
+                                </div>
                             </div>
-                        </div>
-                        <div class="col-sm-6 col-xl-3">
-                            <div class="activity-kpi">
-                                <div class="activity-kpi-label">Client History Rows</div>
-                                <div class="activity-kpi-value" id="kpiClientHistoryRows">0</div>
+                            <div class="col-sm-6 col-xl-3">
+                                <div class="activity-kpi">
+                                    <div class="activity-kpi-label">
+                                        Client History Rows
+                                    </div>
+                                    <div
+                                        class="activity-kpi-value"
+                                        id="kpiClientHistoryRows"
+                                    >
+                                        0
+                                    </div>
+                                </div>
                             </div>
-                        </div>
-                        <div class="col-sm-6 col-xl-3">
-                            <div class="activity-kpi">
-                                <div class="activity-kpi-label">Locked IPs</div>
-                                <div class="activity-kpi-value" id="kpiLockedIps">0</div>
+                            <div class="col-sm-6 col-xl-3">
+                                <div class="activity-kpi">
+                                    <div class="activity-kpi-label">
+                                        Locked IPs
+                                    </div>
+                                    <div
+                                        class="activity-kpi-value"
+                                        id="kpiLockedIps"
+                                    >
+                                        0
+                                    </div>
+                                </div>
                             </div>
-                        </div>
-                        <div class="col-12">
-                            <div class="activity-section">
-                                <div class="activity-section-head mb-0">
-                                    <div>
-                                        <h5 class="mb-0">Overview</h5>
-                                        <div class="activity-section-subtitle">Use the left sidebar to focus on one data set at a time</div>
+                            <div class="col-12">
+                                <div class="activity-section">
+                                    <div class="activity-section-head mb-0">
+                                        <div>
+                                            <h5 class="mb-0">Overview</h5>
+                                            <div
+                                                class="activity-section-subtitle"
+                                            >
+                                                Use the left sidebar to focus on
+                                                one data set at a time
+                                            </div>
+                                        </div>
                                     </div>
                                 </div>
                             </div>
                         </div>
                     </div>
-                </div>
 
-                <div class="activity-section-pane d-none" id="section-realtime" data-section="realtime">
-                    <section class="activity-section">
-                        <div class="activity-section-head">
-                            <div>
-                                <h5 class="mb-0">Realtime Monitor</h5>
-                                <div class="activity-section-subtitle">Current transfer sessions and recently seen clients</div>
+                    <div
+                        class="activity-section-pane d-none"
+                        id="section-realtime"
+                        data-section="realtime"
+                    >
+                        <section class="activity-section">
+                            <div class="activity-section-head">
+                                <div>
+                                    <h5 class="mb-0">Realtime Monitor</h5>
+                                    <div class="activity-section-subtitle">
+                                        Current transfer sessions and recently
+                                        seen clients
+                                    </div>
+                                </div>
                             </div>
-                        </div>
 
-                        <div class="row g-3">
-                            <div class="col-xl-6">
-                                <div class="card activity-card">
-                                    <div class="card-body">
-                                        <div class="d-flex align-items-center justify-content-between">
-                                            <h6 class="card-title mb-0">Live transfers</h6>
-                                            <span class="badge text-bg-secondary" id="liveTransfersCount">0</span>
+                            <div class="row g-3">
+                                <div class="col-xl-6">
+                                    <div class="activity-card">
+                                        <div class="card-body">
+                                            <div
+                                                class="d-flex align-items-center justify-content-between"
+                                            >
+                                                <h6 class="card-title mb-0">
+                                                    Live transfers
+                                                </h6>
+                                                <span
+                                                    class="badge text-bg-secondary"
+                                                    id="liveTransfersCount"
+                                                    >0</span
+                                                >
+                                            </div>
+                                            <div
+                                                class="table-responsive mt-3 activity-scroll-full"
+                                            >
+                                                <table
+                                                    class="table table-sm table-striped align-middle activity-table"
+                                                >
+                                                    <thead>
+                                                        <tr>
+                                                            <th scope="col">
+                                                                Started
+                                                            </th>
+                                                            <th scope="col">
+                                                                User
+                                                            </th>
+                                                            <th scope="col">
+                                                                Remote
+                                                            </th>
+                                                            <th scope="col">
+                                                                Location
+                                                            </th>
+                                                            <th scope="col">
+                                                                Title
+                                                            </th>
+                                                            <th scope="col">
+                                                                File
+                                                            </th>
+                                                            <th scope="col">
+                                                                Sent
+                                                            </th>
+                                                        </tr>
+                                                    </thead>
+                                                    <tbody
+                                                        id="liveTransfersBody"
+                                                    >
+                                                        <tr>
+                                                            <td
+                                                                colspan="7"
+                                                                class="table-muted-empty"
+                                                            >
+                                                                Loading...
+                                                            </td>
+                                                        </tr>
+                                                    </tbody>
+                                                </table>
+                                            </div>
                                         </div>
-                                        <div class="table-responsive mt-3 activity-scroll-full">
-                                            <table class="table table-sm table-striped align-middle activity-table">
-                                                <thead>
-                                                    <tr>
-                                                        <th scope="col">Started</th>
-                                                        <th scope="col">User</th>
-                                                        <th scope="col">Remote</th>
-                                                        <th scope="col">Location</th>
-                                                        <th scope="col">Title</th>
-                                                        <th scope="col">File</th>
-                                                        <th scope="col">Sent</th>
-                                                    </tr>
-                                                </thead>
-                                                <tbody id="liveTransfersBody">
-                                                    <tr><td colspan="7" class="table-muted-empty">Loading...</td></tr>
-                                                </tbody>
-                                            </table>
+                                    </div>
+                                </div>
+
+                                <div class="col-xl-6">
+                                    <div class="activity-card">
+                                        <div class="card-body">
+                                            <div
+                                                class="d-flex align-items-center justify-content-between"
+                                            >
+                                                <h6 class="card-title mb-0">
+                                                    Connected clients
+                                                </h6>
+                                                <span
+                                                    class="badge text-bg-secondary"
+                                                    id="connectedClientsCount"
+                                                    >0</span
+                                                >
+                                            </div>
+                                            <div
+                                                class="table-responsive mt-3 activity-scroll-full"
+                                            >
+                                                <table
+                                                    class="table table-sm table-striped align-middle activity-table"
+                                                >
+                                                    <thead>
+                                                        <tr>
+                                                            <th scope="col">
+                                                                Last seen
+                                                            </th>
+                                                            <th scope="col">
+                                                                User
+                                                            </th>
+                                                            <th scope="col">
+                                                                Remote
+                                                            </th>
+                                                            <th scope="col">
+                                                                Location
+                                                            </th>
+                                                            <th scope="col">
+                                                                User-Agent
+                                                            </th>
+                                                            <th scope="col">
+                                                                Client details
+                                                            </th>
+                                                        </tr>
+                                                    </thead>
+                                                    <tbody
+                                                        id="connectedClientsBody"
+                                                    >
+                                                        <tr>
+                                                            <td
+                                                                colspan="6"
+                                                                class="table-muted-empty"
+                                                            >
+                                                                Loading...
+                                                            </td>
+                                                        </tr>
+                                                    </tbody>
+                                                </table>
+                                            </div>
                                         </div>
                                     </div>
                                 </div>
                             </div>
+                        </section>
+                    </div>
 
-                            <div class="col-xl-6">
-                                <div class="card activity-card">
-                                    <div class="card-body">
-                                        <div class="d-flex align-items-center justify-content-between">
-                                            <h6 class="card-title mb-0">Connected clients</h6>
-                                            <span class="badge text-bg-secondary" id="connectedClientsCount">0</span>
+                    <div
+                        class="activity-section-pane d-none"
+                        id="section-access"
+                        data-section="access"
+                    >
+                        <section class="activity-section">
+                            <div class="activity-section-head">
+                                <div>
+                                    <h5 class="mb-0">Access History</h5>
+                                    <div class="activity-section-subtitle">
+                                        Searchable and sortable recent
+                                        transfer/shop activity
+                                    </div>
+                                </div>
+                            </div>
+
+                            <div class="activity-card">
+                                <div class="card-body">
+                                    <div class="activity-toolbar">
+                                        <div>
+                                            <h6 class="card-title mb-0">
+                                                Access history
+                                                <span
+                                                    class="badge text-bg-secondary ms-1"
+                                                    id="accessHistoryCount"
+                                                    >0</span
+                                                >
+                                            </h6>
+                                            <div
+                                                class="activity-section-subtitle"
+                                            >
+                                                Recent transfers and shop
+                                                activity
+                                            </div>
                                         </div>
-                                        <div class="table-responsive mt-3 activity-scroll-full">
-                                            <table class="table table-sm table-striped align-middle activity-table">
-                                                <thead>
-                                                    <tr>
-                                                        <th scope="col">Last seen</th>
-                                                        <th scope="col">User</th>
-                                                        <th scope="col">Remote</th>
-                                                        <th scope="col">Location</th>
-                                                        <th scope="col">User-Agent</th>
-                                                        <th scope="col">Client details</th>
-                                                    </tr>
-                                                </thead>
-                                                <tbody id="connectedClientsBody">
-                                                    <tr><td colspan="6" class="table-muted-empty">Loading...</td></tr>
-                                                </tbody>
-                                            </table>
+                                        <div class="activity-toolbar-group">
+                                            <button
+                                                type="button"
+                                                class="btn btn-outline-danger btn-sm"
+                                                id="clearAccessHistoryBtn"
+                                            >
+                                                <i class="bi bi-trash"></i>
+                                                Clear log
+                                            </button>
+                                            <button
+                                                type="button"
+                                                class="btn btn-outline-secondary btn-sm"
+                                                id="exportAccessHistoryBtn"
+                                            >
+                                                <i class="bi bi-download"></i>
+                                                Export CSV
+                                            </button>
+                                            <input
+                                                id="accessSearch"
+                                                class="form-control form-control-sm"
+                                                style="width: 260px"
+                                                placeholder="Search by user, title, file, IP, kind"
+                                                autocomplete="off"
+                                            />
+                                            <label
+                                                class="text-muted small mb-0"
+                                                for="activityLimit"
+                                                >Rows</label
+                                            >
+                                            <select
+                                                id="activityLimit"
+                                                class="form-select form-select-sm"
+                                                style="width: 90px"
+                                            >
+                                                <option value="50">50</option>
+                                                <option value="100" selected>
+                                                    100
+                                                </option>
+                                                <option value="250">250</option>
+                                            </select>
                                         </div>
                                     </div>
-                                </div>
-                            </div>
-                        </div>
-                    </section>
-                </div>
-
-                <div class="activity-section-pane d-none" id="section-access" data-section="access">
-                    <section class="activity-section">
-                        <div class="activity-section-head">
-                            <div>
-                                <h5 class="mb-0">Access History</h5>
-                                <div class="activity-section-subtitle">Searchable and sortable recent transfer/shop activity</div>
-                            </div>
-                        </div>
-
-                        <div class="card activity-card">
-                            <div class="card-body">
-                                <div class="activity-toolbar">
-                                    <div>
-                                        <h6 class="card-title mb-0">Access history <span class="badge text-bg-secondary ms-1" id="accessHistoryCount">0</span></h6>
-                                        <div class="activity-section-subtitle">Recent transfers and shop activity</div>
-                                    </div>
-                                    <div class="activity-toolbar-group">
-                                        <button type="button" class="btn btn-outline-danger btn-sm" id="clearAccessHistoryBtn">
-                                            <i class="bi bi-trash"></i> Clear log
-                                        </button>
-                                        <button type="button" class="btn btn-outline-secondary btn-sm" id="exportAccessHistoryBtn">
-                                            <i class="bi bi-download"></i> Export CSV
-                                        </button>
-                                        <input
-                                            id="accessSearch"
-                                            class="form-control form-control-sm"
-                                            style="width: 260px;"
-                                            placeholder="Search by user, title, file, IP, kind"
-                                            autocomplete="off"
-                                        />
-                                        <label class="text-muted small mb-0" for="activityLimit">Rows</label>
-                                        <select id="activityLimit" class="form-select form-select-sm" style="width: 90px;">
-                                            <option value="50">50</option>
-                                            <option value="100" selected>100</option>
-                                            <option value="250">250</option>
-                                        </select>
-                                    </div>
-                                </div>
-                                <div class="table-responsive mt-3 activity-scroll-full">
-                                    <table class="table table-sm table-striped align-middle activity-table">
-                                        <thead>
-                                            <tr>
-                                                <th scope="col" class="sortable" data-sort-key="at">When</th>
-                                                <th scope="col" class="sortable" data-sort-key="kind">Kind</th>
-                                                <th scope="col" class="sortable" data-sort-key="user">User</th>
-                                                <th scope="col" class="sortable" data-sort-key="remote_addr">Remote</th>
-                                                <th scope="col" class="sortable" data-sort-key="country">Location</th>
-                                                <th scope="col" class="sortable" data-sort-key="title_id">Title</th>
-                                                <th scope="col" class="sortable" data-sort-key="filename">File</th>
-                                                <th scope="col" class="sortable" data-sort-key="bytes_sent">Bytes</th>
-                                                <th scope="col" class="sortable" data-sort-key="ok">Status</th>
-                                            </tr>
-                                        </thead>
-                                        <tbody id="accessHistoryBody">
-                                            <tr><td colspan="9" class="table-muted-empty">Loading...</td></tr>
-                                        </tbody>
-                                    </table>
-                                </div>
-                            </div>
-                        </div>
-                    </section>
-                </div>
-
-                <div class="activity-section-pane d-none" id="section-clients" data-section="clients">
-                    <section class="activity-section">
-                        <div class="activity-section-head">
-                            <div>
-                                <h5 class="mb-0">Client History</h5>
-                                <div class="activity-section-subtitle">Persisted log of connected clients and metadata</div>
-                            </div>
-                        </div>
-
-                        <div class="card activity-card">
-                            <div class="card-body">
-                                <div class="activity-toolbar">
-                                    <div>
-                                        <h6 class="card-title mb-0">Client history <span class="badge text-bg-secondary ms-1" id="clientHistoryCount">0</span></h6>
-                                        <div class="activity-section-subtitle">Persisted log of connected clients</div>
-                                    </div>
-                                    <div class="activity-toolbar-group">
-                                        <button type="button" class="btn btn-outline-danger btn-sm" id="clearClientsHistoryBtn">
-                                            <i class="bi bi-trash"></i> Clear log
-                                        </button>
-                                        <button type="button" class="btn btn-outline-secondary btn-sm" id="exportClientsHistoryBtn">
-                                            <i class="bi bi-download"></i> Export CSV
-                                        </button>
-                                        <label class="text-muted small mb-0" for="clientsHistoryLimit">Rows</label>
-                                        <select id="clientsHistoryLimit" class="form-select form-select-sm" style="width: 90px;">
-                                            <option value="100">100</option>
-                                            <option value="250" selected>250</option>
-                                            <option value="500">500</option>
-                                            <option value="2000">2000</option>
-                                        </select>
+                                    <div
+                                        class="table-responsive mt-3 activity-scroll-full"
+                                    >
+                                        <table
+                                            class="table table-sm table-striped align-middle activity-table"
+                                        >
+                                            <thead>
+                                                <tr>
+                                                    <th
+                                                        scope="col"
+                                                        class="sortable"
+                                                        data-sort-key="at"
+                                                    >
+                                                        When
+                                                    </th>
+                                                    <th
+                                                        scope="col"
+                                                        class="sortable"
+                                                        data-sort-key="kind"
+                                                    >
+                                                        Kind
+                                                    </th>
+                                                    <th
+                                                        scope="col"
+                                                        class="sortable"
+                                                        data-sort-key="user"
+                                                    >
+                                                        User
+                                                    </th>
+                                                    <th
+                                                        scope="col"
+                                                        class="sortable"
+                                                        data-sort-key="remote_addr"
+                                                    >
+                                                        Remote
+                                                    </th>
+                                                    <th
+                                                        scope="col"
+                                                        class="sortable"
+                                                        data-sort-key="country"
+                                                    >
+                                                        Location
+                                                    </th>
+                                                    <th
+                                                        scope="col"
+                                                        class="sortable"
+                                                        data-sort-key="title_id"
+                                                    >
+                                                        Title
+                                                    </th>
+                                                    <th
+                                                        scope="col"
+                                                        class="sortable"
+                                                        data-sort-key="filename"
+                                                    >
+                                                        File
+                                                    </th>
+                                                    <th
+                                                        scope="col"
+                                                        class="sortable"
+                                                        data-sort-key="bytes_sent"
+                                                    >
+                                                        Bytes
+                                                    </th>
+                                                    <th
+                                                        scope="col"
+                                                        class="sortable"
+                                                        data-sort-key="ok"
+                                                    >
+                                                        Status
+                                                    </th>
+                                                </tr>
+                                            </thead>
+                                            <tbody id="accessHistoryBody">
+                                                <tr>
+                                                    <td
+                                                        colspan="9"
+                                                        class="table-muted-empty"
+                                                    >
+                                                        Loading...
+                                                    </td>
+                                                </tr>
+                                            </tbody>
+                                        </table>
                                     </div>
                                 </div>
-                                <div class="table-responsive mt-3 activity-scroll-full">
-                                    <table class="table table-sm table-striped align-middle activity-table">
-                                        <thead>
-                                            <tr>
-                                                <th scope="col">When</th>
-                                                <th scope="col">User</th>
-                                                <th scope="col">Remote</th>
-                                                <th scope="col">Location</th>
-                                                <th scope="col">User-Agent</th>
-                                                <th scope="col">Client details</th>
-                                                <th scope="col"></th>
-                                            </tr>
-                                        </thead>
-                                        <tbody id="clientsHistoryBody">
-                                            <tr><td colspan="7" class="table-muted-empty">Loading...</td></tr>
-                                        </tbody>
-                                    </table>
-                                </div>
                             </div>
-                        </div>
-                    </section>
-                </div>
+                        </section>
+                    </div>
 
-                <div class="activity-section-pane d-none" id="section-blocked" data-section="blocked">
-                    <section class="activity-section">
-                        <div class="activity-section-head">
-                            <div>
-                                <h5 class="mb-0">Blocked IPs</h5>
-                                <div class="activity-section-subtitle">Requests blocked by the permanent IP blacklist</div>
-                            </div>
-                        </div>
-
-                        <div class="card activity-card">
-                            <div class="card-body">
-                                <div class="activity-toolbar">
-                                    <div>
-                                        <h6 class="card-title mb-0">Blocked requests <span class="badge text-bg-secondary ms-1" id="blockedIpsCount">0</span></h6>
-                                        <div class="activity-section-subtitle">404 responses returned for blacklisted IPs</div>
-                                    </div>
-                                    <div class="activity-toolbar-group">
-                                        <input
-                                            id="blockedIpsSearch"
-                                            class="form-control form-control-sm"
-                                            style="width: 260px;"
-                                            placeholder="Search by IP, path, UA"
-                                            autocomplete="off"
-                                        />
+                    <div
+                        class="activity-section-pane d-none"
+                        id="section-clients"
+                        data-section="clients"
+                    >
+                        <section class="activity-section">
+                            <div class="activity-section-head">
+                                <div>
+                                    <h5 class="mb-0">Client History</h5>
+                                    <div class="activity-section-subtitle">
+                                        Persisted log of connected clients and
+                                        metadata
                                     </div>
                                 </div>
-                                <div class="table-responsive mt-3 activity-scroll-full">
-                                    <table class="table table-sm table-striped align-middle activity-table">
-                                        <thead>
-                                            <tr>
-                                                <th scope="col">When</th>
-                                                <th scope="col">Remote</th>
-                                                <th scope="col">Location</th>
-                                                <th scope="col">Path</th>
-                                                <th scope="col">User-Agent</th>
-                                                <th scope="col">Status</th>
-                                            </tr>
-                                        </thead>
-                                        <tbody id="blockedIpsBody">
-                                            <tr><td colspan="6" class="table-muted-empty">Loading...</td></tr>
-                                        </tbody>
-                                    </table>
-                                </div>
                             </div>
-                        </div>
-                    </section>
-                </div>
-                
-                <div class="activity-section-pane d-none" id="section-lockouts" data-section="lockouts">
-                    <section class="activity-section">
-                        <div class="activity-section-head">
-                            <div>
-                                <h5 class="mb-0">Login Lockouts</h5>
-                                <div class="activity-section-subtitle">Current temporary IP lockouts from failed authentication attempts</div>
-                            </div>
-                        </div>
 
-                        <div class="card activity-card">
-                            <div class="card-body">
-                                <div class="activity-toolbar">
-                                    <div>
-                                        <h6 class="card-title mb-0">Temporary lockouts <span class="badge text-bg-secondary ms-1" id="authLockoutsCountActivity">0</span></h6>
-                                        <div class="activity-section-subtitle">Unlock individual IPs or clear all temporary lockouts</div>
+                            <div class="activity-card">
+                                <div class="card-body">
+                                    <div class="activity-toolbar">
+                                        <div>
+                                            <h6 class="card-title mb-0">
+                                                Client history
+                                                <span
+                                                    class="badge text-bg-secondary ms-1"
+                                                    id="clientHistoryCount"
+                                                    >0</span
+                                                >
+                                            </h6>
+                                            <div
+                                                class="activity-section-subtitle"
+                                            >
+                                                Persisted log of connected
+                                                clients
+                                            </div>
+                                        </div>
+                                        <div class="activity-toolbar-group">
+                                            <button
+                                                type="button"
+                                                class="btn btn-outline-danger btn-sm"
+                                                id="clearClientsHistoryBtn"
+                                            >
+                                                <i class="bi bi-trash"></i>
+                                                Clear log
+                                            </button>
+                                            <button
+                                                type="button"
+                                                class="btn btn-outline-secondary btn-sm"
+                                                id="exportClientsHistoryBtn"
+                                            >
+                                                <i class="bi bi-download"></i>
+                                                Export CSV
+                                            </button>
+                                            <label
+                                                class="text-muted small mb-0"
+                                                for="clientsHistoryLimit"
+                                                >Rows</label
+                                            >
+                                            <select
+                                                id="clientsHistoryLimit"
+                                                class="form-select form-select-sm"
+                                                style="width: 90px"
+                                            >
+                                                <option value="100">100</option>
+                                                <option value="250" selected>
+                                                    250
+                                                </option>
+                                                <option value="500">500</option>
+                                                <option value="2000">
+                                                    2000
+                                                </option>
+                                            </select>
+                                        </div>
                                     </div>
-                                    <div class="activity-toolbar-group">
-                                        <button type="button" class="btn btn-outline-secondary btn-sm" id="refreshAuthLockoutsBtnActivity">
-                                            <i class="bi bi-arrow-clockwise"></i> Refresh
-                                        </button>
-                                        <button type="button" class="btn btn-outline-danger btn-sm" id="unlockAllAuthLockoutsBtnActivity">
-                                            <i class="bi bi-unlock"></i> Unlock all
-                                        </button>
+                                    <div
+                                        class="table-responsive mt-3 activity-scroll-full"
+                                    >
+                                        <table
+                                            class="table table-sm table-striped align-middle activity-table"
+                                        >
+                                            <thead>
+                                                <tr>
+                                                    <th scope="col">When</th>
+                                                    <th scope="col">User</th>
+                                                    <th scope="col">Remote</th>
+                                                    <th scope="col">
+                                                        Location
+                                                    </th>
+                                                    <th scope="col">
+                                                        User-Agent
+                                                    </th>
+                                                    <th scope="col">
+                                                        Client details
+                                                    </th>
+                                                    <th scope="col"></th>
+                                                </tr>
+                                            </thead>
+                                            <tbody id="clientsHistoryBody">
+                                                <tr>
+                                                    <td
+                                                        colspan="7"
+                                                        class="table-muted-empty"
+                                                    >
+                                                        Loading...
+                                                    </td>
+                                                </tr>
+                                            </tbody>
+                                        </table>
                                     </div>
-                                </div>
-
-                                <div class="table-responsive mt-3 activity-scroll-full">
-                                    <table class="table table-sm table-striped align-middle activity-table">
-                                        <thead>
-                                            <tr>
-                                                <th scope="col">IP</th>
-                                                <th scope="col">Remaining</th>
-                                                <th scope="col">Last failed</th>
-                                                <th scope="col">Attempts</th>
-                                                <th scope="col">Action</th>
-                                            </tr>
-                                        </thead>
-                                        <tbody id="authLockoutsBodyActivity">
-                                            <tr><td colspan="5" class="table-muted-empty">Loading...</td></tr>
-                                        </tbody>
-                                    </table>
                                 </div>
                             </div>
-                        </div>
-                    </section>
-                </div>
+                        </section>
+                    </div>
+
+                    <div
+                        class="activity-section-pane d-none"
+                        id="section-blocked"
+                        data-section="blocked"
+                    >
+                        <section class="activity-section">
+                            <div class="activity-section-head">
+                                <div>
+                                    <h5 class="mb-0">Blocked IPs</h5>
+                                    <div class="activity-section-subtitle">
+                                        Requests blocked by the permanent IP
+                                        blacklist
+                                    </div>
+                                </div>
+                            </div>
+
+                            <div class="activity-card">
+                                <div class="card-body">
+                                    <div class="activity-toolbar">
+                                        <div>
+                                            <h6 class="card-title mb-0">
+                                                Blocked requests
+                                                <span
+                                                    class="badge text-bg-secondary ms-1"
+                                                    id="blockedIpsCount"
+                                                    >0</span
+                                                >
+                                            </h6>
+                                            <div
+                                                class="activity-section-subtitle"
+                                            >
+                                                404 responses returned for
+                                                blacklisted IPs
+                                            </div>
+                                        </div>
+                                        <div class="activity-toolbar-group">
+                                            <input
+                                                id="blockedIpsSearch"
+                                                class="form-control form-control-sm"
+                                                style="width: 260px"
+                                                placeholder="Search by IP, path, UA"
+                                                autocomplete="off"
+                                            />
+                                        </div>
+                                    </div>
+                                    <div
+                                        class="table-responsive mt-3 activity-scroll-full"
+                                    >
+                                        <table
+                                            class="table table-sm table-striped align-middle activity-table"
+                                        >
+                                            <thead>
+                                                <tr>
+                                                    <th scope="col">When</th>
+                                                    <th scope="col">Remote</th>
+                                                    <th scope="col">
+                                                        Location
+                                                    </th>
+                                                    <th scope="col">Path</th>
+                                                    <th scope="col">
+                                                        User-Agent
+                                                    </th>
+                                                    <th scope="col">Status</th>
+                                                </tr>
+                                            </thead>
+                                            <tbody id="blockedIpsBody">
+                                                <tr>
+                                                    <td
+                                                        colspan="6"
+                                                        class="table-muted-empty"
+                                                    >
+                                                        Loading...
+                                                    </td>
+                                                </tr>
+                                            </tbody>
+                                        </table>
+                                    </div>
+                                </div>
+                            </div>
+                        </section>
+                    </div>
+
+                    <div
+                        class="activity-section-pane d-none"
+                        id="section-lockouts"
+                        data-section="lockouts"
+                    >
+                        <section class="activity-section">
+                            <div class="activity-section-head">
+                                <div>
+                                    <h5 class="mb-0">Login Lockouts</h5>
+                                    <div class="activity-section-subtitle">
+                                        Current temporary IP lockouts from
+                                        failed authentication attempts
+                                    </div>
+                                </div>
+                            </div>
+
+                            <div class="activity-card">
+                                <div class="card-body">
+                                    <div class="activity-toolbar">
+                                        <div>
+                                            <h6 class="card-title mb-0">
+                                                Temporary lockouts
+                                                <span
+                                                    class="badge text-bg-secondary ms-1"
+                                                    id="authLockoutsCountActivity"
+                                                    >0</span
+                                                >
+                                            </h6>
+                                            <div
+                                                class="activity-section-subtitle"
+                                            >
+                                                Unlock individual IPs or clear
+                                                all temporary lockouts
+                                            </div>
+                                        </div>
+                                        <div class="activity-toolbar-group">
+                                            <button
+                                                type="button"
+                                                class="btn btn-outline-secondary btn-sm"
+                                                id="refreshAuthLockoutsBtnActivity"
+                                            >
+                                                <i
+                                                    class="bi bi-arrow-clockwise"
+                                                ></i>
+                                                Refresh
+                                            </button>
+                                            <button
+                                                type="button"
+                                                class="btn btn-outline-danger btn-sm"
+                                                id="unlockAllAuthLockoutsBtnActivity"
+                                            >
+                                                <i class="bi bi-unlock"></i>
+                                                Unlock all
+                                            </button>
+                                        </div>
+                                    </div>
+
+                                    <div
+                                        class="table-responsive mt-3 activity-scroll-full"
+                                    >
+                                        <table
+                                            class="table table-sm table-striped align-middle activity-table"
+                                        >
+                                            <thead>
+                                                <tr>
+                                                    <th scope="col">IP</th>
+                                                    <th scope="col">
+                                                        Remaining
+                                                    </th>
+                                                    <th scope="col">
+                                                        Last failed
+                                                    </th>
+                                                    <th scope="col">
+                                                        Attempts
+                                                    </th>
+                                                    <th scope="col">Action</th>
+                                                </tr>
+                                            </thead>
+                                            <tbody
+                                                id="authLockoutsBodyActivity"
+                                            >
+                                                <tr>
+                                                    <td
+                                                        colspan="5"
+                                                        class="table-muted-empty"
+                                                    >
+                                                        Loading...
+                                                    </td>
+                                                </tr>
+                                            </tbody>
+                                        </table>
+                                    </div>
+                                </div>
+                            </div>
+                        </section>
+                    </div>
                 </div>
             </div>
         </div>
@@ -800,24 +1274,24 @@
 <script>
     function formatTime(tsSeconds) {
         if (!tsSeconds) {
-            return '-';
+            return "-";
         }
         try {
             const d = new Date(tsSeconds * 1000);
             return d.toLocaleString();
         } catch (e) {
-            return '-';
+            return "-";
         }
     }
 
     function formatBytes(bytes) {
         if (bytes === null || bytes === undefined) {
-            return '-';
+            return "-";
         }
-        const units = ['B', 'KB', 'MB', 'GB', 'TB'];
+        const units = ["B", "KB", "MB", "GB", "TB"];
         let size = Number(bytes);
         if (!Number.isFinite(size)) {
-            return '-';
+            return "-";
         }
         let unitIndex = 0;
         while (size >= 1024 && unitIndex < units.length - 1) {
@@ -828,12 +1302,12 @@
     }
 
     function escapeHtml(s) {
-        return String(s ?? '')
-            .replaceAll('&', '&amp;')
-            .replaceAll('<', '&lt;')
-            .replaceAll('>', '&gt;')
-            .replaceAll('"', '&quot;')
-            .replaceAll("'", '&#39;');
+        return String(s ?? "")
+            .replaceAll("&", "&amp;")
+            .replaceAll("<", "&lt;")
+            .replaceAll(">", "&gt;")
+            .replaceAll('"', "&quot;")
+            .replaceAll("'", "&#39;");
     }
 
     function setText(id, value) {
@@ -841,106 +1315,129 @@
         if (!el) {
             return;
         }
-        el.textContent = String(value ?? '');
+        el.textContent = String(value ?? "");
     }
 
     let lastActivityRefreshAt = null;
     let lastClientsRefreshAt = null;
 
     function updateLastRefreshLabel() {
-        const latest = Math.max(lastActivityRefreshAt || 0, lastClientsRefreshAt || 0);
+        const latest = Math.max(
+            lastActivityRefreshAt || 0,
+            lastClientsRefreshAt || 0,
+        );
         if (!latest) {
-            setText('lastRefreshLabel', 'Last update: -');
+            setText("lastRefreshLabel", "Last update: -");
             return;
         }
         const asSeconds = Math.floor(latest / 1000);
-        setText('lastRefreshLabel', `Last update: ${formatTime(asSeconds)}`);
+        setText("lastRefreshLabel", `Last update: ${formatTime(asSeconds)}`);
     }
 
     function updateActivityLayoutMetrics() {
-        const nav = document.querySelector('nav.navbar');
-        const navHeight = Math.max(40, Math.round(nav?.getBoundingClientRect?.().height || 56));
-        document.documentElement.style.setProperty('--activity-nav-h', `${navHeight}px`);
+        const nav = document.querySelector("nav.navbar");
+        const navHeight = Math.max(
+            40,
+            Math.round(nav?.getBoundingClientRect?.().height || 56),
+        );
+        document.documentElement.style.setProperty(
+            "--activity-nav-h",
+            `${navHeight}px`,
+        );
     }
 
     function showError(message) {
-        const el = $('#activityAlert');
-        el.text(message || 'Failed to load activity.').removeClass('d-none');
+        const el = $("#activityAlert");
+        el.text(message || "Failed to load activity.").removeClass("d-none");
     }
 
     function renderClientDetails(item) {
         const fields = [
-            ['Theme', item?.theme],
-            ['UID', item?.uid],
-            ['Version', item?.version],
-            ['Revision', item?.revision],
-            ['Language', item?.language],
-            ['HAUTH', item?.hauth],
-            ['UAUTH', item?.uauth],
+            ["Theme", item?.theme],
+            ["UID", item?.uid],
+            ["Version", item?.version],
+            ["Revision", item?.revision],
+            ["Language", item?.language],
+            ["HAUTH", item?.hauth],
+            ["UAUTH", item?.uauth],
         ];
         const lines = [];
         fields.forEach(([label, raw]) => {
-            const value = String(raw ?? '').trim();
+            const value = String(raw ?? "").trim();
             if (!value) {
                 return;
             }
-            const isCodeValue = ['UID', 'HAUTH', 'UAUTH'].includes(label);
+            const isCodeValue = ["UID", "HAUTH", "UAUTH"].includes(label);
             lines.push(
-                `<div class="client-kv">`
-                + `<span class="client-k">${label}</span>`
-                + `<span class="client-v ${isCodeValue ? 'mono-value' : ''}">${escapeHtml(value)}</span>`
-                + `</div>`
+                `<div class="client-kv">` +
+                    `<span class="client-k">${label}</span>` +
+                    `<span class="client-v ${isCodeValue ? "mono-value" : ""}">${escapeHtml(value)}</span>` +
+                    `</div>`,
             );
         });
         if (!lines.length) {
             return '<span class="text-muted">-</span>';
         }
-        return `<div class="client-detail-stack">${lines.join('')}</div>`;
+        return `<div class="client-detail-stack">${lines.join("")}</div>`;
     }
 
     function hideError() {
-        $('#activityAlert').addClass('d-none').text('');
+        $("#activityAlert").addClass("d-none").text("");
     }
 
     function showActivitySection(sectionName) {
-        const section = ['overview', 'realtime', 'access', 'blocked', 'clients', 'lockouts'].includes(String(sectionName))
+        const section = [
+            "overview",
+            "realtime",
+            "access",
+            "blocked",
+            "clients",
+            "lockouts",
+        ].includes(String(sectionName))
             ? String(sectionName)
-            : 'overview';
-        $('.activity-section-pane').addClass('d-none');
-        $(`#section-${section}`).removeClass('d-none');
-        $('#activityNav .nav-link').removeClass('active');
-        $(`#activityNav .nav-link[data-section="${section}"]`).addClass('active');
+            : "overview";
+        $(".activity-section-pane").addClass("d-none");
+        $(`#section-${section}`).removeClass("d-none");
+        $("#activityNav .nav-link").removeClass("active");
+        $(`#activityNav .nav-link[data-section="${section}"]`).addClass(
+            "active",
+        );
         if (window.location.hash !== `#${section}`) {
-            history.replaceState(null, '', `#${section}`);
+            history.replaceState(null, "", `#${section}`);
         }
-        if (section === 'lockouts') {
+        if (section === "lockouts") {
             loadAuthLockouts();
         }
 
         if ($(window).width() < 768) {
-            $('#activitySidebar').removeClass('show');
-            $('body').removeClass('activity-sidebar-open');
+            $("#activitySidebar").removeClass("show");
+            $("body").removeClass("activity-sidebar-open");
         }
     }
 
     function toggleActivitySidebar() {
-        $('#activitySidebar').toggleClass('show');
-        $('body').toggleClass('activity-sidebar-open', $('#activitySidebar').hasClass('show'));
+        $("#activitySidebar").toggleClass("show");
+        $("body").toggleClass(
+            "activity-sidebar-open",
+            $("#activitySidebar").hasClass("show"),
+        );
     }
 
     function renderLiveTransfers(items) {
-        const body = $('#liveTransfersBody');
+        const body = $("#liveTransfersBody");
         const list = Array.isArray(items) ? items : [];
-        setText('liveTransfersCount', list.length);
-        setText('kpiLiveTransfers', list.length);
+        setText("liveTransfersCount", list.length);
+        setText("kpiLiveTransfers", list.length);
 
         if (!list.length) {
-            body.html('<tr><td colspan="7" class="table-muted-empty">No active transfers.</td></tr>');
+            body.html(
+                '<tr><td colspan="7" class="table-muted-empty">No active transfers.</td></tr>',
+            );
             return;
         }
 
         body.empty();
-        list.forEach(item => {
+        list.forEach((item) => {
             const locParts = [];
             if (item.city) {
                 locParts.push(item.city);
@@ -951,19 +1448,23 @@
             if (item.country) {
                 locParts.push(item.country);
             }
-            const locationLabel = locParts.length ? locParts.join(', ') : '-';
-            const countryCode = String(item.country_code || '').trim().toLowerCase();
-            const flagIcon = countryCode ? `<img src="https://cdn.jsdelivr.net/npm/flag-icons@7.2.3/flags/4x3/${countryCode}.svg" alt="" class="flag-icon" loading="lazy" />` : '';
+            const locationLabel = locParts.length ? locParts.join(", ") : "-";
+            const countryCode = String(item.country_code || "")
+                .trim()
+                .toLowerCase();
+            const flagIcon = countryCode
+                ? `<img src="https://cdn.jsdelivr.net/npm/flag-icons@7.2.3/flags/4x3/${countryCode}.svg" alt="" class="flag-icon" loading="lazy" />`
+                : "";
             const row = $(
                 `<tr>
                     <td>${escapeHtml(formatTime(item.started_at))}</td>
-                    <td>${escapeHtml(item.user || '-')}</td>
-                    <td>${escapeHtml(item.remote_addr || '-')}</td>
+                    <td>${escapeHtml(item.user || "-")}</td>
+                    <td>${escapeHtml(item.remote_addr || "-")}</td>
                     <td><span class="location-cell">${flagIcon}${escapeHtml(locationLabel)}</span></td>
-                    <td>${escapeHtml(item.title_id || '-')}${item.title_name ? ` <span class="text-muted">(${escapeHtml(item.title_name)})</span>` : ''}</td>
-                    <td class="text-truncate" style="max-width: 300px;">${escapeHtml(item.filename || '-') }</td>
+                    <td>${escapeHtml(item.title_id || "-")}${item.title_name ? ` <span class="text-muted">(${escapeHtml(item.title_name)})</span>` : ""}</td>
+                    <td class="text-truncate" style="max-width: 300px;">${escapeHtml(item.filename || "-")}</td>
                     <td>${escapeHtml(formatBytes(item.bytes_sent))}</td>
-                </tr>`
+                </tr>`,
             );
             body.append(row);
         });
@@ -971,52 +1472,58 @@
 
     let accessHistoryAll = [];
     let accessHistoryRendered = [];
-    let accessHistorySortKey = 'at';
-    let accessHistorySortDir = 'desc';
-    let accessHistoryQuery = '';
-    let blockedIpsQuery = '';
+    let accessHistorySortKey = "at";
+    let accessHistorySortDir = "desc";
+    let accessHistoryQuery = "";
+    let blockedIpsQuery = "";
 
     function formatIsoTime(tsSeconds) {
         if (!tsSeconds) {
-            return '';
+            return "";
         }
         try {
             return new Date(tsSeconds * 1000).toISOString();
         } catch (e) {
-            return '';
+            return "";
         }
     }
 
     function getSortValue(item, key) {
         if (!item) {
-            return '';
+            return "";
         }
-        if (key === 'ok') {
-            return item.ok === true ? 2 : (item.ok === false ? 1 : 0);
+        if (key === "ok") {
+            return item.ok === true ? 2 : item.ok === false ? 1 : 0;
         }
         const value = item[key];
         if (value === null || value === undefined) {
-            return '';
+            return "";
         }
         return value;
     }
 
     function refreshSortIndicators() {
-        $('th.sortable').each(function () {
+        $("th.sortable").each(function () {
             const th = $(this);
-            th.removeClass('sorted-asc sorted-desc');
-            if (String(th.data('sort-key')) === String(accessHistorySortKey)) {
-                th.addClass(accessHistorySortDir === 'asc' ? 'sorted-asc' : 'sorted-desc');
+            th.removeClass("sorted-asc sorted-desc");
+            if (String(th.data("sort-key")) === String(accessHistorySortKey)) {
+                th.addClass(
+                    accessHistorySortDir === "asc"
+                        ? "sorted-asc"
+                        : "sorted-desc",
+                );
             }
         });
     }
 
     function applyAccessHistoryView() {
-        const q = (accessHistoryQuery || '').trim().toLowerCase();
-        let list = Array.isArray(accessHistoryAll) ? accessHistoryAll.slice() : [];
+        const q = (accessHistoryQuery || "").trim().toLowerCase();
+        let list = Array.isArray(accessHistoryAll)
+            ? accessHistoryAll.slice()
+            : [];
 
         if (q) {
-            list = list.filter(item => {
+            list = list.filter((item) => {
                 const hay = [
                     item.at,
                     item.kind,
@@ -1032,20 +1539,23 @@
                     item.filename,
                     item.bytes_sent,
                     item.status_code,
-                ].map(v => String(v ?? '')).join(' ').toLowerCase();
+                ]
+                    .map((v) => String(v ?? ""))
+                    .join(" ")
+                    .toLowerCase();
                 return hay.includes(q);
             });
         }
 
-        const dir = accessHistorySortDir === 'asc' ? 1 : -1;
+        const dir = accessHistorySortDir === "asc" ? 1 : -1;
         const key = accessHistorySortKey;
         list.sort((a, b) => {
             const av = getSortValue(a, key);
             const bv = getSortValue(b, key);
-            if (typeof av === 'number' && typeof bv === 'number') {
+            if (typeof av === "number" && typeof bv === "number") {
                 return dir * (av - bv);
             }
-            if (key === 'at' || key === 'bytes_sent') {
+            if (key === "at" || key === "bytes_sent") {
                 const an = Number(av) || 0;
                 const bn = Number(bv) || 0;
                 return dir * (an - bn);
@@ -1059,39 +1569,54 @@
     }
 
     function exportAccessHistoryCsv() {
-        const list = Array.isArray(accessHistoryRendered) ? accessHistoryRendered : [];
+        const list = Array.isArray(accessHistoryRendered)
+            ? accessHistoryRendered
+            : [];
         const rows = [];
-        rows.push(['at', 'kind', 'user', 'remote_addr', 'title_id', 'title_name', 'filename', 'bytes_sent', 'ok', 'status_code', 'duration_ms']);
-        list.forEach(item => {
+        rows.push([
+            "at",
+            "kind",
+            "user",
+            "remote_addr",
+            "title_id",
+            "title_name",
+            "filename",
+            "bytes_sent",
+            "ok",
+            "status_code",
+            "duration_ms",
+        ]);
+        list.forEach((item) => {
             rows.push([
                 formatIsoTime(item.at),
-                item.kind ?? '',
-                item.user ?? '',
-                item.remote_addr ?? '',
-                item.title_id ?? '',
-                item.title_name ?? '',
-                item.filename ?? '',
-                item.bytes_sent ?? '',
-                item.ok ?? '',
-                item.status_code ?? '',
-                item.duration_ms ?? '',
+                item.kind ?? "",
+                item.user ?? "",
+                item.remote_addr ?? "",
+                item.title_id ?? "",
+                item.title_name ?? "",
+                item.filename ?? "",
+                item.bytes_sent ?? "",
+                item.ok ?? "",
+                item.status_code ?? "",
+                item.duration_ms ?? "",
             ]);
         });
 
         function csvEscape(value) {
-            const s = String(value ?? '');
+            const s = String(value ?? "");
             if (/[\r\n\",]/.test(s)) {
                 return '"' + s.replaceAll('"', '""') + '"';
             }
             return s;
         }
 
-        const csv = rows.map(r => r.map(csvEscape).join(',')).join('\n') + '\n';
-        const blob = new Blob([csv], { type: 'text/csv;charset=utf-8' });
+        const csv =
+            rows.map((r) => r.map(csvEscape).join(",")).join("\n") + "\n";
+        const blob = new Blob([csv], { type: "text/csv;charset=utf-8" });
         const url = URL.createObjectURL(blob);
-        const a = document.createElement('a');
+        const a = document.createElement("a");
         a.href = url;
-        a.download = 'access_history.csv';
+        a.download = "access_history.csv";
         document.body.appendChild(a);
         a.click();
         a.remove();
@@ -1099,18 +1624,20 @@
     }
 
     function renderConnectedClients(items) {
-        const body = $('#connectedClientsBody');
+        const body = $("#connectedClientsBody");
         const list = Array.isArray(items) ? items : [];
-        setText('connectedClientsCount', list.length);
-        setText('kpiConnectedClients', list.length);
+        setText("connectedClientsCount", list.length);
+        setText("kpiConnectedClients", list.length);
 
         if (!list.length) {
-            body.html('<tr><td colspan="6" class="table-muted-empty">No recent clients.</td></tr>');
+            body.html(
+                '<tr><td colspan="6" class="table-muted-empty">No recent clients.</td></tr>',
+            );
             return;
         }
 
         body.empty();
-        list.forEach(item => {
+        list.forEach((item) => {
             const locParts = [];
             if (item.city) {
                 locParts.push(item.city);
@@ -1121,54 +1648,64 @@
             if (item.country) {
                 locParts.push(item.country);
             }
-            const locationLabel = locParts.length ? locParts.join(', ') : '-';
-            const countryCode = String(item.country_code || '').trim().toLowerCase();
-            const flagIcon = countryCode ? `<img src="https://cdn.jsdelivr.net/npm/flag-icons@7.2.3/flags/4x3/${countryCode}.svg" alt="" class="flag-icon" loading="lazy" />` : '';
+            const locationLabel = locParts.length ? locParts.join(", ") : "-";
+            const countryCode = String(item.country_code || "")
+                .trim()
+                .toLowerCase();
+            const flagIcon = countryCode
+                ? `<img src="https://cdn.jsdelivr.net/npm/flag-icons@7.2.3/flags/4x3/${countryCode}.svg" alt="" class="flag-icon" loading="lazy" />`
+                : "";
             const row = $(
                 `<tr>
                     <td>${escapeHtml(formatTime(item.last_seen_at))}</td>
-                    <td>${escapeHtml(item.user || '-')}</td>
-                    <td>${escapeHtml(item.remote_addr || '-')}</td>
+                    <td>${escapeHtml(item.user || "-")}</td>
+                    <td>${escapeHtml(item.remote_addr || "-")}</td>
                     <td><span class="location-cell">${flagIcon}${escapeHtml(locationLabel)}</span></td>
-                    <td class="text-truncate" style="max-width: 520px;">${escapeHtml(item.user_agent || '-')}</td>
+                    <td class="text-truncate" style="max-width: 520px;">${escapeHtml(item.user_agent || "-")}</td>
                     <td style="min-width: 280px;">${renderClientDetails(item)}</td>
-                </tr>`
+                </tr>`,
             );
             body.append(row);
         });
     }
 
     function kindBadgeClass(kind) {
-        const normalized = String(kind || '').toLowerCase();
-        if (normalized === 'transfer') {
-            return 'text-bg-primary';
+        const normalized = String(kind || "").toLowerCase();
+        if (normalized === "transfer") {
+            return "text-bg-primary";
         }
-        if (normalized === 'shop' || normalized === 'shop_sections' || normalized === 'shop_media') {
-            return 'text-bg-info';
+        if (
+            normalized === "shop" ||
+            normalized === "shop_sections" ||
+            normalized === "shop_media"
+        ) {
+            return "text-bg-info";
         }
-        if (normalized === 'client_seen') {
-            return 'text-bg-secondary';
+        if (normalized === "client_seen") {
+            return "text-bg-secondary";
         }
-        if (normalized.includes('error') || normalized.includes('failed')) {
-            return 'text-bg-danger';
+        if (normalized.includes("error") || normalized.includes("failed")) {
+            return "text-bg-danger";
         }
-        return 'text-bg-light border text-dark';
+        return "text-bg-light border text-dark";
     }
 
     function renderAccessHistory(items) {
-        const body = $('#accessHistoryBody');
+        const body = $("#accessHistoryBody");
         const list = Array.isArray(items) ? items : [];
-        setText('accessHistoryCount', list.length);
-        setText('kpiAccessRows', list.length);
+        setText("accessHistoryCount", list.length);
+        setText("kpiAccessRows", list.length);
         if (!list.length) {
-            const msg = (accessHistoryQuery || '').trim()
-                ? 'No history rows match your search.'
-                : 'No history yet.';
-            body.html(`<tr><td colspan="9" class="table-muted-empty">${escapeHtml(msg)}</td></tr>`);
+            const msg = (accessHistoryQuery || "").trim()
+                ? "No history rows match your search."
+                : "No history yet.";
+            body.html(
+                `<tr><td colspan="9" class="table-muted-empty">${escapeHtml(msg)}</td></tr>`,
+            );
             return;
         }
         body.empty();
-        list.forEach(item => {
+        list.forEach((item) => {
             const locParts = [];
             if (item.city) {
                 locParts.push(item.city);
@@ -1179,47 +1716,58 @@
             if (item.country) {
                 locParts.push(item.country);
             }
-            const locationLabel = locParts.length ? locParts.join(', ') : '-';
-            const countryCode = String(item.country_code || '').trim().toLowerCase();
-            const flagIcon = countryCode ? `<img src="https://cdn.jsdelivr.net/npm/flag-icons@7.2.3/flags/4x3/${countryCode}.svg" alt="" class="flag-icon" loading="lazy" />` : '';
-            const statusText = item.ok === true ? 'OK' : (item.ok === false ? 'Fail' : '-');
-            const statusClass = item.ok === true
-                ? 'text-bg-success'
-                : (item.ok === false ? 'text-bg-danger' : 'text-bg-secondary');
-            const statusCodeLabel = item.status_code ? ` ${escapeHtml(item.status_code)}` : '';
+            const locationLabel = locParts.length ? locParts.join(", ") : "-";
+            const countryCode = String(item.country_code || "")
+                .trim()
+                .toLowerCase();
+            const flagIcon = countryCode
+                ? `<img src="https://cdn.jsdelivr.net/npm/flag-icons@7.2.3/flags/4x3/${countryCode}.svg" alt="" class="flag-icon" loading="lazy" />`
+                : "";
+            const statusText =
+                item.ok === true ? "OK" : item.ok === false ? "Fail" : "-";
+            const statusClass =
+                item.ok === true
+                    ? "text-bg-success"
+                    : item.ok === false
+                      ? "text-bg-danger"
+                      : "text-bg-secondary";
+            const statusCodeLabel = item.status_code
+                ? ` ${escapeHtml(item.status_code)}`
+                : "";
 
-            const bytesLabel = item.kind === 'transfer'
-                ? formatBytes(item.bytes_sent)
-                : '-';
+            const bytesLabel =
+                item.kind === "transfer" ? formatBytes(item.bytes_sent) : "-";
             const row = $(
                 `<tr>
                     <td>${escapeHtml(formatTime(item.at))}</td>
-                    <td><span class="badge kind-badge ${kindBadgeClass(item.kind)}">${escapeHtml(item.kind || '-')}</span></td>
-                    <td>${escapeHtml(item.user || '-')}</td>
-                    <td>${escapeHtml(item.remote_addr || '-')}</td>
+                    <td><span class="badge kind-badge ${kindBadgeClass(item.kind)}">${escapeHtml(item.kind || "-")}</span></td>
+                    <td>${escapeHtml(item.user || "-")}</td>
+                    <td>${escapeHtml(item.remote_addr || "-")}</td>
                     <td><span class="location-cell">${flagIcon}${escapeHtml(locationLabel)}</span></td>
-                    <td>${escapeHtml(item.title_id || '-')}${item.title_name ? ` <span class="text-muted">(${escapeHtml(item.title_name)})</span>` : ''}</td>
-                    <td class="text-truncate" style="max-width: 420px;">${escapeHtml(item.filename || '-') }</td>
+                    <td>${escapeHtml(item.title_id || "-")}${item.title_name ? ` <span class="text-muted">(${escapeHtml(item.title_name)})</span>` : ""}</td>
+                    <td class="text-truncate" style="max-width: 420px;">${escapeHtml(item.filename || "-")}</td>
                     <td>${escapeHtml(bytesLabel)}</td>
                     <td><span class="badge ${statusClass}">${statusText}${statusCodeLabel}</span></td>
-                </tr>`
+                </tr>`,
             );
             body.append(row);
         });
     }
 
     function renderClientsHistory(items) {
-        const body = $('#clientsHistoryBody');
+        const body = $("#clientsHistoryBody");
         const list = Array.isArray(items) ? items : [];
-        setText('clientHistoryCount', list.length);
-        setText('kpiClientHistoryRows', list.length);
+        setText("clientHistoryCount", list.length);
+        setText("kpiClientHistoryRows", list.length);
         if (!list.length) {
-            body.html('<tr><td colspan="7" class="table-muted-empty">No client history yet.</td></tr>');
+            body.html(
+                '<tr><td colspan="7" class="table-muted-empty">No client history yet.</td></tr>',
+            );
             return;
         }
 
         body.empty();
-        list.forEach(item => {
+        list.forEach((item) => {
             const locParts = [];
             if (item.city) {
                 locParts.push(item.city);
@@ -1230,38 +1778,44 @@
             if (item.country) {
                 locParts.push(item.country);
             }
-            const locationLabel = locParts.length ? locParts.join(', ') : '-';
-            const countryCode = String(item.country_code || '').trim().toLowerCase();
-            const flagIcon = countryCode ? `<img src="https://cdn.jsdelivr.net/npm/flag-icons@7.2.3/flags/4x3/${countryCode}.svg" alt="" class="flag-icon" loading="lazy" />` : '';
+            const locationLabel = locParts.length ? locParts.join(", ") : "-";
+            const countryCode = String(item.country_code || "")
+                .trim()
+                .toLowerCase();
+            const flagIcon = countryCode
+                ? `<img src="https://cdn.jsdelivr.net/npm/flag-icons@7.2.3/flags/4x3/${countryCode}.svg" alt="" class="flag-icon" loading="lazy" />`
+                : "";
             const row = $(
                 `<tr>
                     <td>${escapeHtml(formatTime(item.at))}</td>
-                    <td>${escapeHtml(item.user || '-')}</td>
-                    <td>${escapeHtml(item.remote_addr || '-')}</td>
+                    <td>${escapeHtml(item.user || "-")}</td>
+                    <td>${escapeHtml(item.remote_addr || "-")}</td>
                     <td><span class="location-cell">${flagIcon}${escapeHtml(locationLabel)}</span></td>
-                    <td class="text-truncate" style="max-width: 520px;">${escapeHtml(item.user_agent || '-')}</td>
+                    <td class="text-truncate" style="max-width: 520px;">${escapeHtml(item.user_agent || "-")}</td>
                     <td style="min-width: 280px;">${renderClientDetails(item)}</td>
-                    <td class="text-end"><button type="button" class="btn btn-outline-danger btn-sm blacklist-ip-btn" data-ip="${escapeHtml(item.remote_addr || '')}"><i class="bi bi-shield-slash"></i> Block</button></td>
-                </tr>`
+                    <td class="text-end"><button type="button" class="btn btn-outline-danger btn-sm blacklist-ip-btn" data-ip="${escapeHtml(item.remote_addr || "")}"><i class="bi bi-shield-slash"></i> Block</button></td>
+                </tr>`,
             );
             body.append(row);
         });
     }
 
     function renderBlockedIps(items) {
-        const body = $('#blockedIpsBody');
+        const body = $("#blockedIpsBody");
         const list = Array.isArray(items) ? items : [];
-        setText('blockedIpsCount', list.length);
+        setText("blockedIpsCount", list.length);
         if (!list.length) {
-            const msg = (blockedIpsQuery || '').trim()
-                ? 'No blocked requests match your search.'
-                : 'No blocked requests yet.';
-            body.html(`<tr><td colspan="6" class="table-muted-empty">${escapeHtml(msg)}</td></tr>`);
+            const msg = (blockedIpsQuery || "").trim()
+                ? "No blocked requests match your search."
+                : "No blocked requests yet.";
+            body.html(
+                `<tr><td colspan="6" class="table-muted-empty">${escapeHtml(msg)}</td></tr>`,
+            );
             return;
         }
 
         body.empty();
-        list.forEach(item => {
+        list.forEach((item) => {
             const locParts = [];
             if (item.city) {
                 locParts.push(item.city);
@@ -1272,30 +1826,40 @@
             if (item.country) {
                 locParts.push(item.country);
             }
-            const locationLabel = locParts.length ? locParts.join(', ') : '-';
-            const countryCode = String(item.country_code || '').trim().toLowerCase();
-            const flagIcon = countryCode ? `<img src="https://cdn.jsdelivr.net/npm/flag-icons@7.2.3/flags/4x3/${countryCode}.svg" alt="" class="flag-icon" loading="lazy" />` : '';
-            const statusLabel = item.status_code ? ` ${escapeHtml(item.status_code)}` : '';
+            const locationLabel = locParts.length ? locParts.join(", ") : "-";
+            const countryCode = String(item.country_code || "")
+                .trim()
+                .toLowerCase();
+            const flagIcon = countryCode
+                ? `<img src="https://cdn.jsdelivr.net/npm/flag-icons@7.2.3/flags/4x3/${countryCode}.svg" alt="" class="flag-icon" loading="lazy" />`
+                : "";
+            const statusLabel = item.status_code
+                ? ` ${escapeHtml(item.status_code)}`
+                : "";
             const row = $(
                 `<tr>
                     <td>${escapeHtml(formatTime(item.at))}</td>
-                    <td>${escapeHtml(item.remote_addr || '-')}</td>
+                    <td>${escapeHtml(item.remote_addr || "-")}</td>
                     <td><span class="location-cell">${flagIcon}${escapeHtml(locationLabel)}</span></td>
-                    <td class="text-truncate" style="max-width: 420px;">${escapeHtml(item.filename || '-')}</td>
-                    <td class="text-truncate" style="max-width: 520px;">${escapeHtml(item.user_agent || '-')}</td>
+                    <td class="text-truncate" style="max-width: 420px;">${escapeHtml(item.filename || "-")}</td>
+                    <td class="text-truncate" style="max-width: 520px;">${escapeHtml(item.user_agent || "-")}</td>
                     <td><span class="badge text-bg-danger">Blocked${statusLabel}</span></td>
-                </tr>`
+                </tr>`,
             );
             body.append(row);
         });
     }
 
     function applyBlockedIpsView() {
-        const q = (blockedIpsQuery || '').trim().toLowerCase();
-        let list = Array.isArray(accessHistoryAll) ? accessHistoryAll.slice() : [];
-        list = list.filter(item => String(item?.kind || '') === 'permanent_ip_blocked');
+        const q = (blockedIpsQuery || "").trim().toLowerCase();
+        let list = Array.isArray(accessHistoryAll)
+            ? accessHistoryAll.slice()
+            : [];
+        list = list.filter(
+            (item) => String(item?.kind || "") === "permanent_ip_blocked",
+        );
         if (q) {
-            list = list.filter(item => {
+            list = list.filter((item) => {
                 const hay = [
                     item.at,
                     item.remote_addr,
@@ -1307,7 +1871,10 @@
                     item.filename,
                     item.user_agent,
                     item.status_code,
-                ].map(v => String(v ?? '')).join(' ').toLowerCase();
+                ]
+                    .map((v) => String(v ?? ""))
+                    .join(" ")
+                    .toLowerCase();
                 return hay.includes(q);
             });
         }
@@ -1317,7 +1884,7 @@
     function formatDurationSeconds(totalSeconds) {
         let sec = parseInt(totalSeconds, 10);
         if (!Number.isFinite(sec) || sec <= 0) {
-            return '0s';
+            return "0s";
         }
         const days = Math.floor(sec / 86400);
         sec -= days * 86400;
@@ -1338,31 +1905,31 @@
         if (sec > 0 && parts.length < 2) {
             parts.push(`${sec}s`);
         }
-        return parts.join(' ');
+        return parts.join(" ");
     }
 
     function setAuthLockoutsPlaceholder(message) {
-        $('#authLockoutsBodyActivity').html(
-            `<tr><td colspan="5" class="table-muted-empty">${escapeHtml(message)}</td></tr>`
+        $("#authLockoutsBodyActivity").html(
+            `<tr><td colspan="5" class="table-muted-empty">${escapeHtml(message)}</td></tr>`,
         );
     }
 
     function renderAuthLockouts(items) {
-        const body = $('#authLockoutsBodyActivity');
+        const body = $("#authLockoutsBodyActivity");
         const list = Array.isArray(items) ? items : [];
-        setText('authLockoutsCountActivity', list.length);
-        setText('kpiLockedIps', list.length);
+        setText("authLockoutsCountActivity", list.length);
+        setText("kpiLockedIps", list.length);
         if (!list.length) {
-            setAuthLockoutsPlaceholder('No temporary lockouts.');
+            setAuthLockoutsPlaceholder("No temporary lockouts.");
             return;
         }
 
         body.empty();
-        list.forEach(item => {
-            const ip = String(item?.ip || '').trim();
+        list.forEach((item) => {
+            const ip = String(item?.ip || "").trim();
             const row = $(
                 `<tr>
-                    <td class="mono-value">${escapeHtml(ip || '-')}</td>
+                    <td class="mono-value">${escapeHtml(ip || "-")}</td>
                     <td>${escapeHtml(formatDurationSeconds(item?.remaining_seconds || 0))}</td>
                     <td>${escapeHtml(formatTime(item?.last_failed_at || 0))}</td>
                     <td>${escapeHtml(String(item?.failed_attempts_recent ?? 0))}</td>
@@ -1371,7 +1938,7 @@
                             <i class="bi bi-unlock"></i> Unlock
                         </button>
                     </td>
-                </tr>`
+                </tr>`,
             );
             body.append(row);
         });
@@ -1382,76 +1949,85 @@
             return;
         }
         loadAuthLockouts.inFlight = true;
-        $('#refreshAuthLockoutsBtnActivity').prop('disabled', true);
-        $.getJSON('/api/auth/lockouts', function (result) {
+        $("#refreshAuthLockoutsBtnActivity").prop("disabled", true);
+        $.getJSON("/api/auth/lockouts", function (result) {
             if (!result || result.success !== true) {
                 renderAuthLockouts([]);
-                setAuthLockoutsPlaceholder('Failed to load lockouts.');
+                setAuthLockoutsPlaceholder("Failed to load lockouts.");
                 return;
             }
             renderAuthLockouts(result.items);
-        }).fail(function () {
-            renderAuthLockouts([]);
-            setAuthLockoutsPlaceholder('Failed to load lockouts.');
-        }).always(function () {
-            loadAuthLockouts.inFlight = false;
-            $('#refreshAuthLockoutsBtnActivity').prop('disabled', false);
-        });
+        })
+            .fail(function () {
+                renderAuthLockouts([]);
+                setAuthLockoutsPlaceholder("Failed to load lockouts.");
+            })
+            .always(function () {
+                loadAuthLockouts.inFlight = false;
+                $("#refreshAuthLockoutsBtnActivity").prop("disabled", false);
+            });
     }
 
     function blockIpFromClientHistory(ip) {
-        const trimmed = String(ip || '').trim();
+        const trimmed = String(ip || "").trim();
         if (!trimmed) {
             return;
         }
         $.ajax({
-            url: '/api/admin/blacklist-ip',
-            method: 'POST',
-            contentType: 'application/json',
+            url: "/api/admin/blacklist-ip",
+            method: "POST",
+            contentType: "application/json",
             data: JSON.stringify({ ip: trimmed }),
-        }).done(function (resp) {
-            if (!resp || !resp.success) {
-                const msg = (resp && resp.error) ? resp.error : 'Failed to add IP to blacklist.';
+        })
+            .done(function (resp) {
+                if (!resp || !resp.success) {
+                    const msg =
+                        resp && resp.error
+                            ? resp.error
+                            : "Failed to add IP to blacklist.";
+                    showError(msg);
+                    return;
+                }
+                showToast(`Blacklisted ${trimmed}`, "success");
+            })
+            .fail(function (xhr) {
+                const msg =
+                    xhr?.responseJSON?.error ||
+                    "Failed to add IP to blacklist.";
                 showError(msg);
-                return;
-            }
-            showToast(`Blacklisted ${trimmed}`, 'success');
-        }).fail(function (xhr) {
-            const msg = xhr?.responseJSON?.error || 'Failed to add IP to blacklist.';
-            showError(msg);
-        });
+            });
     }
 
     function unlockAuthLockout(ip) {
-        const value = String(ip || '').trim();
+        const value = String(ip || "").trim();
         if (!value) {
             return;
         }
         $.ajax({
-            url: '/api/auth/lockouts/unlock',
-            type: 'POST',
+            url: "/api/auth/lockouts/unlock",
+            type: "POST",
             data: JSON.stringify({ ip: value }),
-            contentType: 'application/json',
+            contentType: "application/json",
             complete: function () {
                 loadAuthLockouts();
-            }
+            },
         });
     }
 
     function unlockAllAuthLockouts() {
-        if (!confirm('Unlock all temporarily locked IPs?')) {
+        if (!confirm("Unlock all temporarily locked IPs?")) {
             return;
         }
-        $('#unlockAllAuthLockoutsBtnActivity').prop('disabled', true);
+        $("#unlockAllAuthLockoutsBtnActivity").prop("disabled", true);
         $.ajax({
-            url: '/api/auth/lockouts/unlock-all',
-            type: 'POST',
+            url: "/api/auth/lockouts/unlock-all",
+            type: "POST",
             data: JSON.stringify({}),
-            contentType: 'application/json',
+            contentType: "application/json",
             complete: function () {
-                $('#unlockAllAuthLockoutsBtnActivity').prop('disabled', false);
+                $("#unlockAllAuthLockoutsBtnActivity").prop("disabled", false);
                 loadAuthLockouts();
-            }
+            },
         });
     }
 
@@ -1460,20 +2036,25 @@
             return;
         }
         loadClientsHistory.inFlight = true;
-        const limit = parseInt($('#clientsHistoryLimit').val() || '250', 10);
-        $.getJSON(`/api/admin/clients-history?limit=${encodeURIComponent(limit)}`, function (result) {
-            if (!result || result.success !== true) {
+        const limit = parseInt($("#clientsHistoryLimit").val() || "250", 10);
+        $.getJSON(
+            `/api/admin/clients-history?limit=${encodeURIComponent(limit)}`,
+            function (result) {
+                if (!result || result.success !== true) {
+                    renderClientsHistory([]);
+                    return;
+                }
+                renderClientsHistory(result.history);
+                lastClientsRefreshAt = Date.now();
+                updateLastRefreshLabel();
+            },
+        )
+            .fail(function () {
                 renderClientsHistory([]);
-                return;
-            }
-            renderClientsHistory(result.history);
-            lastClientsRefreshAt = Date.now();
-            updateLastRefreshLabel();
-        }).fail(function () {
-            renderClientsHistory([]);
-        }).always(function () {
-            loadClientsHistory.inFlight = false;
-        });
+            })
+            .always(function () {
+                loadClientsHistory.inFlight = false;
+            });
     }
 
     function loadActivity() {
@@ -1482,51 +2063,66 @@
         }
         loadActivity.inFlight = true;
         hideError();
-        const limit = parseInt($('#activityLimit').val() || '100', 10);
-        $.getJSON(`/api/admin/activity?limit=${encodeURIComponent(limit)}`, function (result) {
-            if (!result || result.success !== true) {
-                showError(result?.message || 'Failed to load activity.');
-                return;
-            }
-            if (result.access_history_error) {
-                showError(`Access history unavailable: ${result.access_history_error}`);
-            }
-            renderLiveTransfers(result.live_transfers);
-            renderConnectedClients(result.connected_clients);
-            accessHistoryAll = Array.isArray(result.access_history) ? result.access_history : [];
-            applyAccessHistoryView();
-            applyBlockedIpsView();
-            lastActivityRefreshAt = Date.now();
-            updateLastRefreshLabel();
-        }).fail(function () {
-            showError('Failed to load activity.');
-        }).always(function () {
-            loadActivity.inFlight = false;
-        });
+        const limit = parseInt($("#activityLimit").val() || "100", 10);
+        $.getJSON(
+            `/api/admin/activity?limit=${encodeURIComponent(limit)}`,
+            function (result) {
+                if (!result || result.success !== true) {
+                    showError(result?.message || "Failed to load activity.");
+                    return;
+                }
+                if (result.access_history_error) {
+                    showError(
+                        `Access history unavailable: ${result.access_history_error}`,
+                    );
+                }
+                renderLiveTransfers(result.live_transfers);
+                renderConnectedClients(result.connected_clients);
+                accessHistoryAll = Array.isArray(result.access_history)
+                    ? result.access_history
+                    : [];
+                applyAccessHistoryView();
+                applyBlockedIpsView();
+                lastActivityRefreshAt = Date.now();
+                updateLastRefreshLabel();
+            },
+        )
+            .fail(function () {
+                showError("Failed to load activity.");
+            })
+            .always(function () {
+                loadActivity.inFlight = false;
+            });
     }
 
     $(document).ready(function () {
         updateActivityLayoutMetrics();
-        $(window).on('resize', updateActivityLayoutMetrics);
+        $(window).on("resize", updateActivityLayoutMetrics);
 
-        const navbarCollapseEl = document.getElementById('navbarNav');
+        const navbarCollapseEl = document.getElementById("navbarNav");
         if (navbarCollapseEl) {
-            navbarCollapseEl.addEventListener('shown.bs.collapse', updateActivityLayoutMetrics);
-            navbarCollapseEl.addEventListener('hidden.bs.collapse', updateActivityLayoutMetrics);
+            navbarCollapseEl.addEventListener(
+                "shown.bs.collapse",
+                updateActivityLayoutMetrics,
+            );
+            navbarCollapseEl.addEventListener(
+                "hidden.bs.collapse",
+                updateActivityLayoutMetrics,
+            );
         }
 
-        $('#activityNav .nav-link').on('click', function (e) {
+        $("#activityNav .nav-link").on("click", function (e) {
             e.preventDefault();
-            showActivitySection($(this).data('section'));
+            showActivitySection($(this).data("section"));
         });
 
-        $('#blockedIpsSearch').on('input', function () {
-            blockedIpsQuery = String($(this).val() || '');
+        $("#blockedIpsSearch").on("input", function () {
+            blockedIpsQuery = String($(this).val() || "");
             applyBlockedIpsView();
         });
 
-        $('#clientsHistoryBody').on('click', '.blacklist-ip-btn', function () {
-            const ip = $(this).data('ip');
+        $("#clientsHistoryBody").on("click", ".blacklist-ip-btn", function () {
+            const ip = $(this).data("ip");
             if (!ip) {
                 return;
             }
@@ -1536,114 +2132,129 @@
             blockIpFromClientHistory(ip);
         });
 
-        $('#activitySidebarToggle, #activitySidebarToggleMobile').on('click', function (e) {
-            e.preventDefault();
-            e.stopPropagation();
-            toggleActivitySidebar();
-        });
+        $("#activitySidebarToggle, #activitySidebarToggleMobile").on(
+            "click",
+            function (e) {
+                e.preventDefault();
+                e.stopPropagation();
+                toggleActivitySidebar();
+            },
+        );
 
-        $(document).on('click', function (e) {
-            if ($(window).width() >= 768 || !$('#activitySidebar').hasClass('show')) {
+        $(document).on("click", function (e) {
+            if (
+                $(window).width() >= 768 ||
+                !$("#activitySidebar").hasClass("show")
+            ) {
                 return;
             }
             if (
-                !$(e.target).closest('#activitySidebar').length
-                && !$(e.target).is('#activitySidebarToggle')
-                && !$(e.target).is('#activitySidebarToggleMobile')
-                && !$(e.target).closest('#activitySidebarToggleMobile').length
+                !$(e.target).closest("#activitySidebar").length &&
+                !$(e.target).is("#activitySidebarToggle") &&
+                !$(e.target).is("#activitySidebarToggleMobile") &&
+                !$(e.target).closest("#activitySidebarToggleMobile").length
             ) {
-                $('#activitySidebar').removeClass('show');
-                $('body').removeClass('activity-sidebar-open');
+                $("#activitySidebar").removeClass("show");
+                $("body").removeClass("activity-sidebar-open");
             }
         });
 
-        $(window).on('hashchange', function () {
-            const target = String(window.location.hash || '').replace('#', '');
+        $(window).on("hashchange", function () {
+            const target = String(window.location.hash || "").replace("#", "");
             if (target) {
                 showActivitySection(target);
             }
         });
 
-        $('#refreshNowBtn').on('click', function () {
+        $("#refreshNowBtn").on("click", function () {
             loadActivity();
             loadClientsHistory();
             loadAuthLockouts();
         });
-        $('#activityLimit').on('change', loadActivity);
-        $('#clientsHistoryLimit').on('change', loadClientsHistory);
-        $('#refreshAuthLockoutsBtnActivity').on('click', function () {
+        $("#activityLimit").on("change", loadActivity);
+        $("#clientsHistoryLimit").on("change", loadClientsHistory);
+        $("#refreshAuthLockoutsBtnActivity").on("click", function () {
             loadAuthLockouts();
         });
-        $('#unlockAllAuthLockoutsBtnActivity').on('click', function () {
+        $("#unlockAllAuthLockoutsBtnActivity").on("click", function () {
             unlockAllAuthLockouts();
         });
-        $(document).on('click', '.unlock-auth-lockout-btn-activity', function () {
-            unlockAuthLockout($(this).data('ip'));
-        });
+        $(document).on(
+            "click",
+            ".unlock-auth-lockout-btn-activity",
+            function () {
+                unlockAuthLockout($(this).data("ip"));
+            },
+        );
 
-        $('#clearClientsHistoryBtn').on('click', function () {
-            if (!confirm('Clear the persisted client history log?')) {
+        $("#clearClientsHistoryBtn").on("click", function () {
+            if (!confirm("Clear the persisted client history log?")) {
                 return;
             }
-            $('#clearClientsHistoryBtn').prop('disabled', true);
+            $("#clearClientsHistoryBtn").prop("disabled", true);
             $.ajax({
-                url: '/api/admin/clients-history/clear',
-                type: 'POST',
-                contentType: 'application/json',
+                url: "/api/admin/clients-history/clear",
+                type: "POST",
+                contentType: "application/json",
                 data: JSON.stringify({}),
                 complete: function () {
-                    $('#clearClientsHistoryBtn').prop('disabled', false);
+                    $("#clearClientsHistoryBtn").prop("disabled", false);
                     loadClientsHistory();
-                }
+                },
             });
         });
 
-        $('#exportClientsHistoryBtn').on('click', function () {
-            const limit = parseInt($('#clientsHistoryLimit').val() || '250', 10);
+        $("#exportClientsHistoryBtn").on("click", function () {
+            const limit = parseInt(
+                $("#clientsHistoryLimit").val() || "250",
+                10,
+            );
             window.location.href = `/api/admin/clients-history.csv?limit=${encodeURIComponent(limit)}`;
         });
 
-        $('#accessSearch').on('input', function () {
-            accessHistoryQuery = String($(this).val() ?? '');
+        $("#accessSearch").on("input", function () {
+            accessHistoryQuery = String($(this).val() ?? "");
             applyAccessHistoryView();
         });
 
-        $('#exportAccessHistoryBtn').on('click', function () {
+        $("#exportAccessHistoryBtn").on("click", function () {
             exportAccessHistoryCsv();
         });
 
-        $('#clearAccessHistoryBtn').on('click', function () {
-            if (!confirm('Clear the persisted access history log?')) {
+        $("#clearAccessHistoryBtn").on("click", function () {
+            if (!confirm("Clear the persisted access history log?")) {
                 return;
             }
-            $('#clearAccessHistoryBtn').prop('disabled', true);
+            $("#clearAccessHistoryBtn").prop("disabled", true);
             $.ajax({
-                url: '/api/admin/access-history/clear',
-                type: 'POST',
-                contentType: 'application/json',
+                url: "/api/admin/access-history/clear",
+                type: "POST",
+                contentType: "application/json",
                 data: JSON.stringify({ include_clients: false }),
                 complete: function () {
-                    $('#clearAccessHistoryBtn').prop('disabled', false);
+                    $("#clearAccessHistoryBtn").prop("disabled", false);
                     loadActivity();
-                }
+                },
             });
         });
 
-        $('th.sortable').on('click', function () {
-            const key = $(this).data('sort-key');
+        $("th.sortable").on("click", function () {
+            const key = $(this).data("sort-key");
             if (!key) {
                 return;
             }
             if (accessHistorySortKey === key) {
-                accessHistorySortDir = accessHistorySortDir === 'asc' ? 'desc' : 'asc';
+                accessHistorySortDir =
+                    accessHistorySortDir === "asc" ? "desc" : "asc";
             } else {
                 accessHistorySortKey = key;
-                accessHistorySortDir = key === 'at' ? 'desc' : 'asc';
+                accessHistorySortDir = key === "at" ? "desc" : "asc";
             }
             applyAccessHistoryView();
         });
 
-        const initialSection = String(window.location.hash || '').replace('#', '') || 'overview';
+        const initialSection =
+            String(window.location.hash || "").replace("#", "") || "overview";
         showActivitySection(initialSection);
         refreshSortIndicators();
         loadActivity();
@@ -1652,7 +2263,7 @@
         setInterval(loadActivity, 2500);
         setInterval(loadClientsHistory, 15000);
         setInterval(loadAuthLockouts, 15000);
-        document.addEventListener('visibilitychange', function () {
+        document.addEventListener("visibilitychange", function () {
             if (!document.hidden) {
                 loadActivity();
                 loadClientsHistory();

--- a/app/templates/downloads.html
+++ b/app/templates/downloads.html
@@ -2,14 +2,20 @@
 {% block content %}
 {% include 'nav.html' %}
 
+<style>
+    .downloads-queue-card .card-body {
+        padding-bottom: 1.25rem;
+    }
+ </style>
+
 <div class="container-fluid setting-body">
     <div class="row">
         <div class="col">
-            <div class="settings-container container-fluid mt-3 px-3 px-xl-4">
-                <div class="d-flex flex-column flex-lg-row justify-content-between gap-2 align-items-lg-center mb-2">
+            <div class="settings-container container mt-3">
+                <div class="d-flex align-items-center justify-content-between gap-3 flex-wrap">
                     <div>
                         <h2 class="pb-2">Downloads</h2>
-                        <p class="text-muted mb-0">Live torrent and usenet status plus the pending AeroFoil download queue.</p>
+                        <p class="text-muted">Live torrent and usenet status plus the pending AeroFoil download queue.</p>
                     </div>
                 </div>
 
@@ -60,14 +66,14 @@
                     </div>
 
                     <div class="col-12">
-                        <div class="card mb-3">
+                        <div class="card mb-3 downloads-queue-card">
                             <div class="card-body">
                                 <div class="d-flex align-items-center justify-content-between mb-2">
                                     <h5 class="card-title mb-0">Queue</h5>
                                     <button type="button" id="checkDownloadsBtn" class="btn btn-outline-primary btn-sm" onclick="checkCompletedDownloads()">Check completed</button>
                                 </div>
                                 <div class="small text-muted mb-2" id="downloadsQueueStatus">Loading...</div>
-                                <div class="table-responsive">
+                                <div class="table-responsive mb-3">
                                     <table class="table table-dark table-sm align-middle mb-0">
                                         <thead>
                                             <tr>

--- a/app/templates/manage.html
+++ b/app/templates/manage.html
@@ -31,10 +31,10 @@
     <div class="row">
         <div class="col">
             <div class="settings-container container mt-3">
-                <div class="d-flex flex-column flex-lg-row justify-content-between gap-2 align-items-lg-center mb-2">
+                <div class="d-flex align-items-center justify-content-between gap-3 flex-wrap">
                     <div>
                         <h2 class="pb-2">Manage</h2>
-                        <p class="text-muted mb-0">Library maintenance actions and converter jobs.</p>
+                        <p class="text-muted">Library maintenance actions and converter jobs.</p>
                     </div>
                     <div class="d-flex align-items-center gap-2">
                         <span class="badge text-bg-secondary" id="manageHealthBadge">Checking converter...</span>
@@ -91,7 +91,7 @@
                                                 <label class="form-check-label" for="deleteUpdatesVerbose">Verbose</label>
                                             </div>
                                             <button type="button" id="deleteUpdatesBtn" class="btn btn-danger ms-auto"
-                                                onClick='deleteOlderUpdates()'>Delete older updates</button>
+                                                onClick='promptDeleteOlderUpdates()'>Delete older updates</button>
                                         </div>
                                     </div>
                                     <div class="border rounded p-3">
@@ -123,7 +123,7 @@
                                                 <label class="form-check-label" for="deleteDuplicatesVerbose">Verbose</label>
                                             </div>
                                             <button type="button" id="deleteDuplicatesBtn" class="btn btn-danger ms-auto"
-                                                onClick='deleteDuplicates()'>Delete duplicates</button>
+                                                onClick='promptDeleteDuplicates()'>Delete duplicates</button>
                                         </div>
                                     </div>
                                 </div>
@@ -234,7 +234,7 @@
                                     <h5 class="card-title mb-0">Task output</h5>
                                     <div class="btn-group">
                                         <button class="btn btn-outline-secondary btn-sm" type="button" onClick="showManageOutput([])">Clear</button>
-                                        <button class="btn btn-outline-danger btn-sm" type="button" id="cancelJobBtn" onClick="cancelActiveJob()" disabled>Cancel</button>
+                                        <button class="btn btn-outline-danger btn-sm" type="button" id="cancelJobBtn" onClick="promptCancelActiveJob()" disabled>Cancel</button>
                                     </div>
                                 </div>
                                 <div class="mb-2">
@@ -281,13 +281,13 @@
     <div class="modal-dialog modal-dialog-centered">
         <div class="modal-content">
             <div class="modal-header">
-                <h1 class="modal-title fs-5" id="manageConfirmModalLabel">Confirm delete</h1>
+                <h1 class="modal-title fs-5" id="manageConfirmModalLabel">Confirm action</h1>
                 <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
             </div>
             <div class="modal-body" id="manageConfirmModalBody">...</div>
             <div class="modal-footer">
                 <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
-                <button type="button" class="btn btn-danger" id="manageConfirmModalBtn">Delete</button>
+                <button type="button" class="btn btn-danger" id="manageConfirmModalBtn">Confirm</button>
             </div>
         </div>
     </div>
@@ -304,32 +304,69 @@
     const manageConfirmModalEl = document.getElementById('manageConfirmModal');
     const manageConfirmModal = manageConfirmModalEl ? new bootstrap.Modal(manageConfirmModalEl) : null;
     let manageConfirmAction = null;
+    const manageConfirmModalBtn = $('#manageConfirmModalBtn');
 
-    function showManageConfirmDialog(title, message, onConfirm) {
+    function showManageConfirmDialog(options) {
         if (!manageConfirmModal) {
             return;
         }
-        manageConfirmAction = onConfirm;
-        $('#manageConfirmModalLabel').text(title);
-        $('#manageConfirmModalBody').text(message);
-        $('#manageConfirmModalBtn').prop('disabled', false);
+        manageConfirmAction = options.onConfirm || null;
+        $('#manageConfirmModalLabel').text(options.title || 'Confirm action');
+        $('#manageConfirmModalBody').text(options.message || '');
+        manageConfirmModalBtn
+            .text(options.confirmLabel || 'Confirm')
+            .removeClass('btn-danger btn-warning btn-primary')
+            .addClass(options.confirmClass || 'btn-danger')
+            .prop('disabled', false);
         manageConfirmModal.show();
     }
 
     if (manageConfirmModalEl) {
         manageConfirmModalEl.addEventListener('hidden.bs.modal', function () {
             manageConfirmAction = null;
-            $('#manageConfirmModalBtn').prop('disabled', false);
+            manageConfirmModalBtn
+                .text('Confirm')
+                .removeClass('btn-warning btn-primary')
+                .addClass('btn-danger')
+                .prop('disabled', false);
         });
     }
 
-    $('#manageConfirmModalBtn').on('click', function () {
+    manageConfirmModalBtn.on('click', function () {
         if (!manageConfirmAction) {
             return;
         }
         $(this).prop('disabled', true);
-        manageConfirmAction();
+        const action = manageConfirmAction;
+        manageConfirmModal.hide();
+        action();
     });
+
+    function promptDeleteOlderUpdates() {
+        const dryRun = $('#deleteUpdatesDryRun').is(':checked');
+        showManageConfirmDialog({
+            title: dryRun ? 'Preview older update cleanup' : 'Delete older updates',
+            message: dryRun
+                ? 'Run a dry run for older update cleanup? No files will be deleted.'
+                : 'Delete older update files and keep only the latest owned update per title?',
+            confirmLabel: dryRun ? 'Run dry run' : 'Delete updates',
+            confirmClass: 'btn-danger',
+            onConfirm: deleteOlderUpdates
+        });
+    }
+
+    function promptDeleteDuplicates() {
+        const dryRun = $('#deleteDuplicatesDryRun').is(':checked');
+        showManageConfirmDialog({
+            title: dryRun ? 'Preview duplicate cleanup' : 'Delete duplicates',
+            message: dryRun
+                ? 'Run a dry run for duplicate cleanup? No files will be deleted.'
+                : 'Delete duplicate owned files and keep one file per app ID and version?',
+            confirmLabel: dryRun ? 'Run dry run' : 'Delete duplicates',
+            confirmClass: 'btn-danger',
+            onConfirm: deleteDuplicates
+        });
+    }
 
     function organizeLibrary() {
         $('#organizeLibraryBtn').prop('disabled', true);
@@ -435,15 +472,16 @@
     }
 
     function promptDeleteOrphanedAddons() {
-        if ($('#deleteOrphanedDryRun').is(':checked')) {
-            deleteOrphanedAddons();
-            return;
-        }
-        showManageConfirmDialog(
-            'Delete orphaned updates and DLC',
-            'Delete all owned updates and DLC entries whose parent title has no owned base game?',
-            deleteOrphanedAddons
-        );
+        const dryRun = $('#deleteOrphanedDryRun').is(':checked');
+        showManageConfirmDialog({
+            title: dryRun ? 'Preview orphaned add-on cleanup' : 'Delete orphaned updates and DLC',
+            message: dryRun
+                ? 'Run a dry run for orphaned updates and DLC? No files will be deleted.'
+                : 'Delete all owned updates and DLC entries whose parent title has no owned base game?',
+            confirmLabel: dryRun ? 'Run dry run' : 'Delete orphaned add-ons',
+            confirmClass: 'btn-danger',
+            onConfirm: deleteOrphanedAddons
+        });
     }
 
     function deleteOrphanedAddons() {
@@ -468,10 +506,6 @@
             },
             complete: function () {
                 $('#deleteOrphanedAddonsBtn').prop('disabled', false);
-                $('#manageConfirmModalBtn').prop('disabled', false);
-                if (manageConfirmModal) {
-                    manageConfirmModal.hide();
-                }
             }
         });
     }
@@ -746,6 +780,19 @@
         if (message) {
             // Status is surfaced via the alert; avoid dumping raw converter output.
         }
+    }
+
+    function promptCancelActiveJob() {
+        if (!activeJobId) {
+            return;
+        }
+        showManageConfirmDialog({
+            title: 'Cancel conversion job',
+            message: 'Cancel the active conversion job? Any in-progress work may stop before the current file completes.',
+            confirmLabel: 'Cancel job',
+            confirmClass: 'btn-danger',
+            onConfirm: cancelActiveJob
+        });
     }
 
     function cancelActiveJob() {

--- a/app/templates/nav.html
+++ b/app/templates/nav.html
@@ -31,6 +31,9 @@
             aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation">
             <span class="navbar-toggler-icon"></span>
         </button>
+        {% set content_titles = ['Downloads', 'Upload', 'Manage'] %}
+        {% set backups_titles = ['Save Data Backups'] %}
+        {% set admin_titles = ['Activity', 'Users'] %}
         <div class="collapse navbar-collapse" id="navbarNav">
             <ul class="navbar-nav">
                 <li class="nav-item">
@@ -47,9 +50,34 @@
                     </a>
                 </li>
                 {% endif %}
+                {% if current_user.is_admin or admin_account_created == false %}
+                <li class="nav-item dropdown">
+                    <a class="nav-link dropdown-toggle{% if title in content_titles %} active" aria-current="page"{% else %}"{% endif %}"
+                        href="#" role="button" data-bs-toggle="dropdown" aria-expanded="false">Content</a>
+                    <ul class="dropdown-menu">
+                        <li><a class="dropdown-item{% if title == 'Downloads' %} active{% endif %}" href="/downloads">Downloads</a></li>
+                        <li><a class="dropdown-item{% if title == 'Upload' %} active{% endif %}" href="/upload">Upload</a></li>
+                        <li><a class="dropdown-item{% if title == 'Manage' %} active{% endif %}" href="/manage">Manage</a></li>
+                    </ul>
+                </li>
+                {% endif %}
                 {% if current_user.is_authenticated and current_user.has_backup_access() %}
-                <li class="nav-item">
-                    <a class="nav-link{% if title == 'Save Data Backups' %} active" aria-current="page"{% else %}"{% endif %}" href="/saves">Save Data Backups</a>
+                <li class="nav-item dropdown">
+                    <a class="nav-link dropdown-toggle{% if title in backups_titles %} active" aria-current="page"{% else %}"{% endif %}"
+                        href="#" role="button" data-bs-toggle="dropdown" aria-expanded="false">Backups</a>
+                    <ul class="dropdown-menu">
+                        <li><a class="dropdown-item{% if title == 'Save Data Backups' %} active{% endif %}" href="/saves">Save Data Backups</a></li>
+                    </ul>
+                </li>
+                {% endif %}
+                {% if current_user.is_admin or admin_account_created == false %}
+                <li class="nav-item dropdown">
+                    <a class="nav-link dropdown-toggle{% if title in admin_titles %} active" aria-current="page"{% else %}"{% endif %}"
+                        href="#" role="button" data-bs-toggle="dropdown" aria-expanded="false">Admin</a>
+                    <ul class="dropdown-menu">
+                        <li><a class="dropdown-item{% if title == 'Users' %} active{% endif %}" href="/users">Users</a></li>
+                        <li><a class="dropdown-item{% if title == 'Activity' %} active{% endif %}" href="/activity">Activity</a></li>
+                    </ul>
                 </li>
                 {% endif %}
                 {% if current_user.is_admin or admin_account_created == false %}
@@ -57,38 +85,9 @@
                     <a class="nav-link{% if title == 'Settings' %} active" aria-current="page"{% else %}"{% endif %}" href="/settings">Settings</a>
                 </li>
                 {% endif %}
-                {% if current_user.is_admin or admin_account_created == false %}
-                <li class="nav-item">
-                    <a class="nav-link{% if title == 'Users' %} active" aria-current="page"{% else %}"{% endif %}" href="/users">Users</a>
-                </li>
-                {% endif %}
-                {% if current_user.is_admin or admin_account_created == false %}
-                <li class="nav-item">
-                    <a class="nav-link{% if title == 'Downloads' %} active" aria-current="page"{% else %}"{% endif %}" href="/downloads">Downloads</a>
-                </li>
-                {% endif %}
-                {% if current_user.is_admin or admin_account_created == false %}
-                <li class="nav-item">
-                    <a class="nav-link{% if title == 'Manage' %} active" aria-current="page"{% else %}"{% endif %}" href="/manage">Manage</a>
-                </li>
-                {% endif %}
-                {% if current_user.is_admin or admin_account_created == false %}
-                <li class="nav-item">
-                    <a class="nav-link{% if title == 'Upload' %} active" aria-current="page"{% else %}"{% endif %}" href="/upload">Upload</a>
-                </li>
-                {% endif %}
-                {% if current_user.is_admin or admin_account_created == false %}
-                <li class="nav-item">
-                    <a class="nav-link{% if title == 'Activity' %} active" aria-current="page"{% else %}"{% endif %}" href="/activity">Activity</a>
-                </li>
-                {% endif %}
             </ul>
             <div class="mx-auto d-flex align-items-center gap-3">
                 <div class="text-muted small d-none" id="librarySizeLabel">Library size: ...</div>
-                <div class="small text-muted d-flex align-items-center gap-2" id="libraryRebuildLabel">
-                    <span class="spinner-border spinner-border-sm text-warning d-none" id="libraryRebuildSpinner" role="status" aria-hidden="true"></span>
-                    <span id="libraryRebuildText">Library: Ready</span>
-                </div>
             </div>
             {% if identification_disabled %}
             <div class="alert alert-warning py-1 px-2 mb-0 small" role="alert">
@@ -99,6 +98,10 @@
                 {% if current_user.is_admin or admin_account_created == false %}
                 <a id="globalJobStatus" class="navbar-text small text-warning d-none text-decoration-none" href="/manage"></a>
                 {% endif %}
+                <div class="small text-muted d-flex align-items-center gap-2" id="libraryRebuildLabel">
+                    <span class="spinner-border spinner-border-sm text-warning d-none" id="libraryRebuildSpinner" role="status" aria-hidden="true"></span>
+                    <span id="libraryRebuildText">Library: Ready</span>
+                </div>
                 {% if current_user.is_authenticated %}
                 <ul class="navbar-nav">
                     <li class="nav-item">

--- a/app/templates/requests.html
+++ b/app/templates/requests.html
@@ -26,47 +26,54 @@
 
         <div class="card bg-dark text-light mb-3">
           <div class="card-body">
-      <div class="row g-3 mb-3">
-        <div class="col-12 col-lg-8">
-          <input type="text" class="form-control" id="requestSearchBox" placeholder="Search by name or title id (e.g. Mario, 0100...)" autocomplete="off">
-          <div class="list-group mt-2" id="requestSearchResults"></div>
-        </div>
-        <div class="col-12 col-lg-4">
-          <div class="border rounded p-3">
-            <div class="fw-semibold">Selected</div>
-            <div class="text-muted small" id="selectedTitleText">None</div>
-            <button class="btn btn-warning btn-sm mt-3" id="submitRequestBtn" disabled>
-              <i class="bi bi-send"></i> Submit request
-            </button>
-            <div class="text-muted small mt-2" id="requestSubmitStatus"></div>
+            <div class="row g-3 mb-3">
+              <div class="col-12">
+                <div class="input-group">
+                  <input type="text" class="form-control" id="requestSearchBox" placeholder="Search by name or title id (e.g. Mario, 0100...)" autocomplete="off">
+                  <button class="btn btn-warning text-nowrap" id="submitRequestBtn" disabled>
+                    <i class="bi bi-send"></i> Submit request
+                  </button>
+                </div>
+                <div class="list-group mt-2" id="requestSearchResults"></div>
+              </div>
+              <div class="col-12">
+                <div class="border rounded p-3 h-100">
+                  <div class="fw-semibold mb-2">Selected</div>
+                  <div class="text-muted small text-truncate text-nowrap" id="selectedTitleText" title="None">None</div>
+                  <div class="form-text mt-2 mb-0">Choose a search result, then submit the request below.</div>
+                </div>
+              </div>
+            </div>
+            <div class="text-muted small border-top pt-3 mb-0" id="requestSubmitStatus"></div>
+
+            {% if current_user.is_admin or admin_account_created == false %}
+            <div class="border-top mt-3 pt-3">
+              <div class="d-flex flex-column flex-lg-row gap-2 align-items-lg-center">
+                <div class="flex-grow-1">
+                  <input type="text" class="form-control" id="adminSearchBox" placeholder="Filter by title id, name, user...">
+                </div>
+              </div>
+              <div class="table-responsive mt-3">
+                <table class="table table-dark table-sm align-middle mb-0">
+                  <thead>
+                    <tr>
+                      <th>Requested</th>
+                      <th>Title</th>
+                      <th>User</th>
+                      <th>Status</th>
+                      <th class="text-end">Actions</th>
+                    </tr>
+                  </thead>
+                  <tbody id="requestsTableBody"></tbody>
+                </table>
+              </div>
+              <div class="text-muted small mt-3" id="requestsStatus"></div>
+            </div>
+            {% else %}
+            {% endif %}
           </div>
         </div>
       </div>
-      {% if current_user.is_admin or admin_account_created == false %}
-      <div class="d-flex flex-column flex-lg-row gap-2 align-items-lg-center">
-        <div class="flex-grow-1">
-          <input type="text" class="form-control" id="adminSearchBox" placeholder="Filter by title id, name, user...">
-        </div>
-      </div>
-      <div class="table-responsive mt-2">
-        <table class="table table-dark table-sm align-middle mb-0">
-          <thead>
-            <tr>
-              <th>Requested</th>
-              <th>Title</th>
-              <th>User</th>
-              <th>Status</th>
-              <th class="text-end">Actions</th>
-            </tr>
-          </thead>
-          <tbody id="requestsTableBody"></tbody>
-        </table>
-      </div>
-      <div class="text-muted small mt-2" id="requestsStatus"></div>
-      {% else %}
-      {% endif %}
-    </div>
-  </div>
       </div>
     </div>
   </div>
@@ -249,7 +256,10 @@
       const results = await fetchSearchResults(q);
       renderTitleSearchResults('requestSearchResults', results, item => {
         selectedTitle = item;
-        document.getElementById('selectedTitleText').textContent = `${item.name || 'Unrecognized'} (${item.id})`;
+        const selectedText = `${item.name || 'Unrecognized'} (${item.id})`;
+        const selectedTitleText = document.getElementById('selectedTitleText');
+        selectedTitleText.textContent = selectedText;
+        selectedTitleText.title = selectedText;
         document.getElementById('submitRequestBtn').disabled = false;
         document.getElementById('requestSubmitStatus').textContent = '';
         document.getElementById('requestSearchBox').value = `${item.name || ''}`.trim();
@@ -269,7 +279,9 @@
       status.textContent = data.message || 'Request created.';
       document.getElementById('submitRequestBtn').disabled = true;
       selectedTitle = null;
-      document.getElementById('selectedTitleText').textContent = 'None';
+      const selectedTitleText = document.getElementById('selectedTitleText');
+      selectedTitleText.textContent = 'None';
+      selectedTitleText.title = 'None';
     } else {
       status.textContent = (data && data.message) ? data.message : 'Request failed.';
     }

--- a/app/templates/settings.html
+++ b/app/templates/settings.html
@@ -2,12 +2,255 @@
 {% block content %}
 {% include 'nav.html' %}
 
-<div class="setting-body">
-    <div class="row g-0">
+<style>
+    :root {
+        --settings-accent: var(--bs-primary);
+        --settings-border: var(--bs-border-color);
+        --settings-muted: var(--bs-secondary-color);
+        --settings-surface-1: var(--bs-body-bg);
+        --settings-surface-2: var(--bs-tertiary-bg);
+        --settings-surface-3: var(--bs-secondary-bg);
+        --settings-nav-h: 56px;
+    }
+
+    .settings-body {
+        padding-left: 0;
+        padding-right: 0;
+        height: calc(100dvh - var(--settings-nav-h));
+        overflow: hidden;
+    }
+
+    .settings-shell-row {
+        height: 100%;
+        min-height: 0;
+    }
+
+    .settings-main-col {
+        height: 100%;
+        overflow: hidden;
+    }
+
+    .settings-main-inner {
+        height: 100%;
+        display: flex;
+        flex-direction: column;
+        gap: 0.85rem;
+        padding: 0.75rem 1rem 1rem;
+    }
+
+    .settings-scroll {
+        min-height: 0;
+        flex: 1 1 auto;
+        overflow-y: auto;
+        padding-right: 0.15rem;
+    }
+
+    .settings-page-header,
+    .settings-section-header {
+        border: 1px solid var(--settings-border);
+        border-radius: var(--aerofoil-card-radius);
+        background: var(--settings-surface-2);
+    }
+
+    .settings-page-header {
+        padding: 1rem 1.1rem;
+        box-shadow: 0 0.35rem 0.9rem rgba(0, 0, 0, 0.08);
+    }
+
+    .settings-section-header {
+        padding: 0.95rem 1.05rem;
+        margin-bottom: 1rem;
+        box-shadow: 0 0.35rem 0.9rem rgba(0, 0, 0, 0.08);
+    }
+
+    .settings-page-subtitle,
+    .settings-section-subtitle,
+    .settings-nav-subtitle {
+        color: var(--settings-muted);
+    }
+
+    .settings-page-meta {
+        display: flex;
+        flex-wrap: wrap;
+        align-items: center;
+        gap: 0.5rem;
+    }
+
+    #settingsSidebar {
+        min-height: 100%;
+        height: 100%;
+        position: sticky;
+        top: var(--settings-nav-h);
+        overflow-y: auto;
+        background-color: rgba(26, 30, 34, 0.98) !important;
+        border-right: 1px solid rgba(255, 255, 255, 0.1) !important;
+    }
+
+    #settingsSidebar .d-flex {
+        border-bottom-color: rgba(255, 255, 255, 0.1) !important;
+    }
+
+    #settingsNav .nav-link {
+        color: rgba(255, 255, 255, 0.75);
+        padding: 0.8rem 1rem;
+        border-radius: 0.5rem;
+        margin-bottom: 0.25rem;
+        transition: all 0.2s ease;
+        display: flex;
+        align-items: flex-start;
+        gap: 0.7rem;
+    }
+
+    #settingsNav .nav-link:hover {
+        color: rgba(255, 255, 255, 0.95);
+        background-color: rgba(255, 255, 255, 0.08);
+    }
+
+    #settingsNav .nav-link.active {
+        color: #fff;
+        background-color: rgba(13, 110, 253, 0.25);
+        font-weight: 500;
+    }
+
+    #settingsNav .nav-link svg {
+        flex-shrink: 0;
+        margin-top: 0.1rem;
+        margin-right: 0.5rem;
+    }
+
+    .settings-nav-copy {
+        display: flex;
+        flex-direction: column;
+        gap: 0.15rem;
+        min-width: 0;
+    }
+
+    .settings-nav-title {
+        line-height: 1.2;
+    }
+
+    .settings-nav-subtitle {
+        font-size: 0.78rem;
+        line-height: 1.25;
+    }
+
+    .settings-panel {
+        margin-bottom: 1rem;
+    }
+
+    .settings-panel.activity-section {
+        padding: 0;
+    }
+
+    .settings-panel .card-body {
+        padding: 1.15rem 1.15rem 1.05rem;
+    }
+
+    .settings-panel-header {
+        margin-bottom: 1.2rem;
+    }
+
+    .settings-panel-header .card-title {
+        margin-bottom: 0.2rem;
+    }
+
+    .settings-panel-actions {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 0.75rem;
+        align-items: center;
+    }
+
+    .settings-option-stack > * + * {
+        margin-top: 0.9rem;
+    }
+
+    .settings-downloads-tabs {
+        margin-bottom: 1rem;
+    }
+
+    .settings-downloads-tabs .nav-link.active {
+        background: var(--settings-surface-1);
+        border-color: var(--settings-border) var(--settings-border) var(--settings-surface-1);
+    }
+
+    @supports not (height: 100dvh) {
+        .settings-body {
+            height: calc(100vh - var(--settings-nav-h));
+        }
+    }
+
+    @media (min-width: 768px) {
+        html,
+        body {
+            overflow-y: hidden;
+        }
+    }
+
+    @media (max-width: 767.98px) {
+        html,
+        body {
+            overflow-y: auto;
+        }
+
+        .settings-body {
+            height: auto;
+            overflow: visible;
+        }
+
+        .settings-main-col {
+            height: auto;
+            overflow: visible;
+        }
+
+        .settings-main-inner {
+            height: auto;
+            overflow: visible;
+            padding: 0.75rem;
+        }
+
+        .settings-scroll {
+            overflow: visible;
+            padding-right: 0;
+        }
+
+        #settingsSidebar {
+            position: fixed;
+            top: var(--settings-nav-h);
+            left: -100%;
+            width: 280px;
+            height: calc(100vh - var(--settings-nav-h));
+            z-index: 1040;
+            transition: left 0.3s ease;
+            box-shadow: 2px 0 8px rgba(0, 0, 0, 0.3);
+        }
+
+        #settingsSidebar.show {
+            left: 0;
+        }
+
+        body.sidebar-open::before {
+            content: "";
+            position: fixed;
+            top: var(--settings-nav-h);
+            left: 0;
+            right: 0;
+            bottom: 0;
+            background: rgba(0, 0, 0, 0.5);
+            z-index: 1039;
+        }
+    }
+</style>
+
+<div class="container-fluid setting-body settings-body">
+    <div class="row g-0 settings-shell-row">
         <!-- Sidebar Navigation -->
-        <div class="col-md-3 col-lg-2 border-end" id="settingsSidebar">
+        <div class="col-md-3 col-xl-2" id="settingsSidebar">
             <div class="d-flex align-items-center justify-content-between p-3 border-bottom">
-                <h5 class="mb-0">Settings</h5>
+                <div>
+                    <h5 class="mb-0">Settings</h5>
+                    <div class="text-muted small">System configuration</div>
+                </div>
                 <button class="btn btn-sm d-md-none" type="button" id="sidebarToggle" aria-label="Toggle sidebar">
                     <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" fill="currentColor" viewBox="0 0 16 16">
                         <path fill-rule="evenodd" d="M2.5 12a.5.5 0 0 1 .5-.5h10a.5.5 0 0 1 0 1H3a.5.5 0 0 1-.5-.5zm0-4a.5.5 0 0 1 .5-.5h10a.5.5 0 0 1 0 1H3a.5.5 0 0 1-.5-.5zm0-4a.5.5 0 0 1 .5-.5h10a.5.5 0 0 1 0 1H3a.5.5 0 0 1-.5-.5z"/>
@@ -19,244 +262,321 @@
                     <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" viewBox="0 0 16 16" style="vertical-align: -0.125em; margin-right: 0.5rem;">
                         <path d="M1 2.828c.885-.37 2.154-.769 3.388-.893 1.33-.134 2.458.063 3.112.752v9.746c-.935-.53-2.12-.603-3.213-.493-1.18.12-2.37.461-3.287.811V2.828zm7.5-.141c.654-.689 1.782-.886 3.112-.752 1.234.124 2.503.523 3.388.893v9.923c-.918-.35-2.107-.692-3.287-.81-1.094-.111-2.278-.039-3.213.492V2.687zM8 1.783C7.015.936 5.587.81 4.287.94c-1.514.153-3.042.672-3.994 1.105A.5.5 0 0 0 0 2.5v11a.5.5 0 0 0 .707.455c.882-.4 2.303-.881 3.68-1.02 1.409-.142 2.59.087 3.223.877a.5.5 0 0 0 .78 0c.633-.79 1.814-1.019 3.222-.877 1.378.139 2.8.62 3.681 1.02A.5.5 0 0 0 16 13.5v-11a.5.5 0 0 0-.293-.455c-.952-.433-2.48-.952-3.994-1.105C10.413.81 8.985.936 8 1.783z"/>
                     </svg>
-                    Library
+                    <span class="settings-nav-copy">
+                        <span class="settings-nav-title">Library</span>
+                        <span class="settings-nav-subtitle">Paths, naming, maintenance, metadata</span>
+                    </span>
                 </a>
                 <a class="nav-link" href="#" data-section="shop">
                     <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" viewBox="0 0 16 16" style="vertical-align: -0.125em; margin-right: 0.5rem;">
                         <path d="M8 1a2.5 2.5 0 0 1 2.5 2.5V4h-5v-.5A2.5 2.5 0 0 1 8 1zm3.5 3v-.5a3.5 3.5 0 1 0-7 0V4H1v10a2 2 0 0 0 2 2h10a2 2 0 0 0 2-2V4h-3.5zM2 5h12v9a1 1 0 0 1-1 1H3a1 1 0 0 1-1-1V5z"/>
                     </svg>
-                    Shop
+                    <span class="settings-nav-copy">
+                        <span class="settings-nav-title">Shop</span>
+                        <span class="settings-nav-subtitle">Access, security, branding, client delivery</span>
+                    </span>
                 </a>
                 <a class="nav-link" href="#" data-section="downloads">
                     <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" viewBox="0 0 16 16" style="vertical-align: -0.125em; margin-right: 0.5rem;">
                         <path d="M.5 9.9a.5.5 0 0 1 .5.5v2.5a1 1 0 0 0 1 1h12a1 1 0 0 0 1-1v-2.5a.5.5 0 0 1 1 0v2.5a2 2 0 0 1-2 2H2a2 2 0 0 1-2-2v-2.5a.5.5 0 0 1 .5-.5z"/>
                         <path d="M7.646 11.854a.5.5 0 0 0 .708 0l3-3a.5.5 0 0 0-.708-.708L8.5 10.293V1.5a.5.5 0 0 0-1 0v8.793L5.354 8.146a.5.5 0 1 0-.708.708l3 3z"/>
                     </svg>
-                    Downloads
+                    <span class="settings-nav-copy">
+                        <span class="settings-nav-title">Downloads</span>
+                        <span class="settings-nav-subtitle">Automation, providers, torrent and usenet clients</span>
+                    </span>
                 </a>
             </nav>
         </div>
         
         <!-- Main Content Area -->
-        <div class="col-md-9 col-lg-10">
-            <!-- Mobile menu button -->
-            <div class="d-md-none p-3 border-bottom">
-                <button class="btn btn-outline-secondary" type="button" id="sidebarToggleMobile" aria-label="Toggle sidebar">
-                    <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" fill="currentColor" viewBox="0 0 16 16" style="vertical-align: -0.125em; margin-right: 0.5rem;">
-                        <path fill-rule="evenodd" d="M2.5 12a.5.5 0 0 1 .5-.5h10a.5.5 0 0 1 0 1H3a.5.5 0 0 1-.5-.5zm0-4a.5.5 0 0 1 .5-.5h10a.5.5 0 0 1 0 1H3a.5.5 0 0 1-.5-.5zm0-4a.5.5 0 0 1 .5-.5h10a.5.5 0 0 1 0 1H3a.5.5 0 0 1-.5-.5z"/>
-                    </svg>
-                    Menu
-                </button>
-            </div>
-            <div class="settings-container container-fluid mt-3">
-
-                <div class="d-flex justify-content-end">
-                    <div class="text-muted small">Version {{ app_version }}</div>
+        <div class="col-md-9 col-xl-10 settings-main-col">
+            <div class="settings-main-inner">
+                <div class="settings-page-header">
+                    <div class="d-flex flex-wrap align-items-start justify-content-between gap-3">
+                        <div>
+                            <h2 class="mb-2">Settings</h2>
+                            <div class="settings-page-subtitle">Configure AeroFoil library behavior, shop access, and download automation from a single workspace.</div>
+                        </div>
+                        <div class="settings-page-meta">
+                            <button class="btn btn-outline-secondary d-md-none" type="button" id="sidebarToggleMobile" aria-label="Toggle sidebar">
+                                <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" fill="currentColor" viewBox="0 0 16 16" style="vertical-align: -0.125em; margin-right: 0.4rem;">
+                                    <path fill-rule="evenodd" d="M2.5 12a.5.5 0 0 1 .5-.5h10a.5.5 0 0 1 0 1H3a.5.5 0 0 1-.5-.5zm0-4a.5.5 0 0 1 .5-.5h10a.5.5 0 0 1 0 1H3a.5.5 0 0 1-.5-.5zm0-4a.5.5 0 0 1 .5-.5h10a.5.5 0 0 1 0 1H3a.5.5 0 0 1-.5-.5z"/>
+                                </svg>
+                                Sections
+                            </button>
+                            <span class="badge text-bg-secondary">Version {{ app_version }}</span>
+                        </div>
+                    </div>
                 </div>
 
-                <!-- <h1>Settings</h1> -->
-
-                {% if admin_account_created == false %}
-                <div class="alert alert-danger" role="alert">
-                    <h4 class="alert-heading">Missing admin account!</h4>
-                    <p>AeroFoil requires an admin account to enable authentication. Until an account with admin rights is
-                        created, <strong>authentication is disabled, anyone can access and change the configuration of
-                            your shop!</strong>
-                        <br>
-                        Add an admin account <a href="/users" class="alert-link">on the Users page</a>.
-                    </p>
-                </div>
-                {% endif %}
-
-                {% if valid_keys == false %}
-                <div id="missingKeysAlert" class="alert alert-warning alert-dismissible fade show" role="alert">
-                    <h4 class="alert-heading">Missing console keys!</h4>
-                    Console keys are required to decrypt any console content, including
-                    backups. AeroFoil uses this to identify files, regardless of the filename.</br>
-                    <strong>Titles will be missed or misidentified if you don't fill in your keys!</strong>
-                    See <a target="_blank" href="https://gitlab.com/easyhacking/switch/-/wikis/home/getting-started/dump-keys" class="alert-link">this guide</a> on
-                    how to extract the
-                    keys from your console, and upload them <a href="/settings#consoleKeysInput" class="alert-link">here
-                        in AeroFoil.</a>
-                    <hr>
-                    If keys are missing, all files <strong>must follow the format "Title Name
-                        [TITLEID][vVERSION]"</strong>, else the file won't be recognized.
-                    <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
-                </div>
-                {% endif %}
-
-                <div id="missingShopHostAlert" class="alert alert-warning alert-dismissible fade show" role="alert" style="display: none;">
-                    <h4 class="alert-heading">Missing shop Host!</h4>
-                    Host verification from outside the local network is disabled if the shop <code>Host</code> is
-                    missing, configure it <a href="/settings#shopHostInput" class="alert-link">here
-                        in AeroFoil</a> to prevent someone else stealing from your shop.
-                    <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
-                </div>
-
-                <div id="missingShopHauthAlert" class="alert alert-warning alert-dismissible fade show" role="alert" style="display: none;">
-                    <h4 class="alert-heading">Missing shop Hauth!</h4>
-                    <a href="https://blawar.github.io/tinfoil/network/#host-signature" class="alert-link"
-                        target="_blank">Host signature</a> verification from outside the local network is disabled if
-                    the shop <code>Hauth</code> is missing. Connect to the shop from Tinfoil with an admin account to
-                    set it.
-                    <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
-                </div>
-
+                <div class="settings-scroll">
                 <!-- Library Section -->
                 <div class="settings-section" id="section-library" data-section="library">
-                <h2 class="pb-3">Library</h2>
-
-                <div class="form-check form-switch mb-3">
-                    <input class="form-check-input" type="checkbox" id="libraryAutoMaintenanceCheck" onChange="submitLibrarySettings()">
-                    <label class="form-check-label" for="libraryAutoMaintenanceCheck">Auto-maintain library</label>
-                    <div class="form-text">Runs library organization and removes empty folders on a schedule.</div>
-                </div>
-
-                <div class="row g-3 mb-3">
-                    <div class="col-md-4">
-                        <label for="libraryMaintenanceIntervalInput" class="form-label">Maintenance interval (minutes)</label>
-                        <input type="number" min="30" class="form-control" id="libraryMaintenanceIntervalInput" onChange="submitLibrarySettings()">
-                        <div class="form-text">Minimum 30 minutes. Values below 30 are clamped.</div>
-                    </div>
-                    <div class="col-md-5 d-flex align-items-end">
-                        <div class="form-check form-switch">
-                            <input class="form-check-input" type="checkbox" id="libraryMaintenanceDeleteUpdatesCheck" onChange="submitLibrarySettings()">
-                            <label class="form-check-label" for="libraryMaintenanceDeleteUpdatesCheck">Delete older updates during maintenance</label>
-                        </div>
-                    </div>
-                    <div class="col-md-3 d-flex align-items-end">
+                <div class="settings-section-header">
+                    <div class="d-flex flex-wrap align-items-start justify-content-between gap-3">
                         <div>
-                            <div class="form-text">Last maintenance run</div>
-                            <div id="libraryMaintenanceLastRun" class="small text-muted">Never</div>
+                            <h3 class="mb-1">Library</h3>
+                            <div class="settings-section-subtitle">Paths, naming, maintenance schedules, and title identification preferences.</div>
                         </div>
                     </div>
                 </div>
-
-                <div class="card mb-3" id="libraryConversionStagingStatusCard">
+                <div class="settings-panel activity-section aerofoil-card">
                     <div class="card-body">
-                        <div class="d-flex align-items-center justify-content-between mb-1">
-                            <div class="fw-semibold">Conversion staging</div>
-                            <span class="badge text-bg-secondary" id="libraryConversionStagingStatusBadge">Disabled</span>
-                        </div>
-                        <div class="small" id="libraryConversionStagingPathLabel">Not enabled</div>
-                        <div class="form-text" id="libraryConversionStagingHint">Set <code>AEROFOIL_CONVERSION_STAGING_ENABLED=true</code> to enable.</div>
-                    </div>
-                </div>
-
-                <div class="card mb-3">
-                    <div class="card-body">
-                        <div class="d-flex flex-wrap gap-2 align-items-end mb-3">
-                            <div class="flex-grow-1" style="min-width: 220px;">
-                                <label for="libraryNamingTemplateSelect" class="form-label mb-1">Organization naming template</label>
-                                <select id="libraryNamingTemplateSelect" class="form-select" onchange="onLibraryNamingTemplateChange()"></select>
-                            </div>
-                            <div>
-                                <button type="button" class="btn btn-outline-primary" onclick="addLibraryNamingTemplate()">Add template</button>
-                            </div>
-                            <div>
-                                <button type="button" class="btn btn-outline-danger" onclick="deleteLibraryNamingTemplate()">Delete template</button>
-                            </div>
+                        <div class="settings-panel-header">
+                            <h5 class="card-title">Library Paths</h5>
+                            <div class="text-muted small">Choose the directories AeroFoil scans and manages.</div>
                         </div>
 
-                        <div class="form-text mb-3">
-                            Tokens: <code>{title}</code>, <code>{title_id}</code>, <code>{app_id}</code>, <code>{version}</code>, <code>{version_txt}</code>, <code>{dlc_name}</code>, <code>{ext}</code> (<code>{version_txt}</code> applies to filename templates only)
-                        </div>
-
-                        <div class="d-flex flex-wrap gap-2 mb-3">
-                            <button type="button" class="btn btn-sm btn-outline-secondary" onclick="applyLibraryNamingPreset('default')">Use Default Preset</button>
-                            <button type="button" class="btn btn-sm btn-outline-secondary" onclick="applyLibraryNamingPreset('flat')">Use Flat Preset</button>
-                            <button type="button" class="btn btn-sm btn-outline-secondary" onclick="applyLibraryNamingPreset('scene')">Use Scene Preset</button>
-                        </div>
-
-                        <div class="mb-3">
-                            <button
-                                class="btn btn-sm btn-success"
-                                type="button"
-                                data-bs-toggle="collapse"
-                                data-bs-target="#collapseLibraryTemplateFields"
-                                aria-expanded="false"
-                                aria-controls="collapseLibraryTemplateFields">
-                                Show template fields
+                        <div class="fw-semibold mb-2">Configured paths</div>
+                        <div id="libraryPathHelp" class="form-text mb-2">Path of directory containing your games.</div>
+                        <table class="table table-hover caption-top mb-0" id="pathsTable">
+                            <thead>
+                                <tr>
+                                    <th scope="col">Path</th>
+                                    <th scope="col">Actions</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                            </tbody>
+                        </table>
+                        <hr class="my-3">
+                        <div class="fw-semibold mb-2">Actions</div>
+                        <div class="settings-panel-actions">
+                            <button class="btn btn-primary" type="button" data-bs-toggle="collapse"
+                                data-bs-target="#collapseNewPath" aria-expanded="false" aria-controls="collapseNewPath">
+                                Add library path
                             </button>
+                            <button type="button" class="btn btn-outline-primary scanBtn" onClick='scanLibrary()'>Scan library</button>
                         </div>
 
-                        <div class="collapse" id="collapseLibraryTemplateFields">
+                        <div class="collapse mt-3" id="collapseNewPath">
+                            <div class="border rounded p-3">
+                                <label class="form-label">Add a new directory</label>
+                                <div class="row g-3 align-items-end">
+                                    <div class="col-lg-8">
+                                        <input type="text" class="form-control" id="libraryPathInput" placeholder="Path">
+                                    </div>
+                                    <div class="col-auto">
+                                        <button type="button" id="submitNewLibraryPathBtn" class="btn btn-primary"
+                                            onClick='submitNewLibraryPath()'>Submit</button>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+
+                <div class="settings-panel activity-section aerofoil-card">
+                    <div class="card-body">
+                        <div class="settings-panel-header">
+                            <div class="d-flex flex-wrap align-items-start justify-content-between gap-3">
+                                <div>
+                                    <h5 class="card-title">Maintenance</h5>
+                                    <div class="text-muted small">Control automatic organization, cleanup, and conversion staging.</div>
+                                </div>
+                                <div class="form-check form-switch mb-0 mt-1">
+                                    <input class="form-check-input" type="checkbox" id="libraryAutoMaintenanceCheck" onChange="submitLibrarySettings()">
+                                    <label class="form-check-label" for="libraryAutoMaintenanceCheck">Auto-maintain library</label>
+                                </div>
+                            </div>
+                        </div>
+
+                        <div class="form-text mb-3">Runs library organization and removes empty folders on a schedule.</div>
+
+                        <div class="row g-3 mb-3">
+                            <div class="col-lg-7">
+                                <div class="border rounded p-3 h-100">
+                                    <div class="fw-semibold mb-2">Schedule</div>
+                                    <div class="row g-3 align-items-end">
+                                        <div class="col-sm-7">
+                                            <label for="libraryMaintenanceIntervalInput" class="form-label">Maintenance interval (minutes)</label>
+                                            <input type="number" min="30" class="form-control" id="libraryMaintenanceIntervalInput" onChange="submitLibrarySettings()">
+                                            <div class="form-text">Minimum 30 minutes. Values below 30 are clamped.</div>
+                                        </div>
+                                        <div class="col-sm-5">
+                                            <div class="form-text">Last maintenance run</div>
+                                            <div id="libraryMaintenanceLastRun" class="small text-muted">Never</div>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                            <div class="col-lg-5">
+                                <div class="border rounded p-3 h-100">
+                                    <div class="fw-semibold mb-2">Cleanup</div>
+                                    <div class="form-check form-switch mb-2">
+                                        <input class="form-check-input" type="checkbox" id="libraryMaintenanceDeleteUpdatesCheck" onChange="submitLibrarySettings()">
+                                        <label class="form-check-label" for="libraryMaintenanceDeleteUpdatesCheck">Delete older updates during maintenance</label>
+                                    </div>
+                                    <div class="form-text mb-0">Keeps the latest owned update per title when maintenance runs.</div>
+                                </div>
+                            </div>
+                        </div>
+
+                        <div class="border rounded p-3" id="libraryConversionStagingStatusCard">
+                            <div class="d-flex align-items-center justify-content-between mb-1">
+                                <div class="fw-semibold">Conversion staging</div>
+                                <span class="badge text-bg-secondary" id="libraryConversionStagingStatusBadge">Disabled</span>
+                            </div>
+                            <div class="small" id="libraryConversionStagingPathLabel">Not enabled</div>
+                            <div class="form-text mb-0" id="libraryConversionStagingHint">Set <code>AEROFOIL_CONVERSION_STAGING_ENABLED=true</code> to enable.</div>
+                        </div>
+                    </div>
+                </div>
+
+                <div class="settings-panel activity-section aerofoil-card">
+                    <div class="card-body">
+                        <div class="settings-panel-header">
+                            <h5 class="card-title">Organization Naming</h5>
+                            <div class="text-muted small">Choose how identified content is organized into folders and filenames.</div>
+                        </div>
+
+                        <div class="border rounded p-3 mb-3">
+                            <div class="fw-semibold mb-2">Template selection</div>
+                            <div class="d-flex flex-wrap gap-2 align-items-end">
+                                <div class="flex-grow-1" style="min-width: 220px;">
+                                    <label for="libraryNamingTemplateSelect" class="form-label mb-1">Organization naming template</label>
+                                    <select id="libraryNamingTemplateSelect" class="form-select" onchange="onLibraryNamingTemplateChange()"></select>
+                                </div>
+                                <div>
+                                    <button type="button" class="btn btn-outline-primary" onclick="addLibraryNamingTemplate()">Add template</button>
+                                </div>
+                                <div>
+                                    <button type="button" class="btn btn-outline-danger" onclick="deleteLibraryNamingTemplate()">Delete template</button>
+                                </div>
+                            </div>
+                        </div>
+
+                        <div class="border rounded p-3 mb-3">
+                            <div class="fw-semibold mb-2">Presets and tokens</div>
+                            <div class="form-text mb-3">
+                                Tokens: <code>{title}</code>, <code>{title_id}</code>, <code>{app_id}</code>, <code>{version}</code>, <code>{version_txt}</code>, <code>{dlc_name}</code>, <code>{ext}</code> (<code>{version_txt}</code> applies to filename templates only)
+                            </div>
+                            <div class="d-flex flex-wrap gap-2">
+                                <button type="button" class="btn btn-sm btn-outline-secondary" onclick="applyLibraryNamingPreset('default')">Use Default Preset</button>
+                                <button type="button" class="btn btn-sm btn-outline-secondary" onclick="applyLibraryNamingPreset('flat')">Use Flat Preset</button>
+                                <button type="button" class="btn btn-sm btn-outline-secondary" onclick="applyLibraryNamingPreset('scene')">Use Scene Preset</button>
+                            </div>
+                        </div>
+
+                        <div class="border rounded p-3">
+                            <div class="d-flex flex-wrap align-items-center justify-content-between gap-2 mb-3">
+                                <div class="fw-semibold">Template fields</div>
+                                <button
+                                    class="btn btn-sm btn-success"
+                                    type="button"
+                                    data-bs-toggle="collapse"
+                                    data-bs-target="#collapseLibraryTemplateFields"
+                                    aria-expanded="false"
+                                    aria-controls="collapseLibraryTemplateFields">
+                                    Show template fields
+                                </button>
+                            </div>
+
+                            <div class="collapse" id="collapseLibraryTemplateFields">
+                                <div class="row g-3">
+                                    <div class="col-md-6">
+                                        <label for="libraryTemplateBaseFolderInput" class="form-label">Base folder template</label>
+                                        <input id="libraryTemplateBaseFolderInput" class="form-control" type="text">
+                                    </div>
+                                    <div class="col-md-6">
+                                        <label for="libraryTemplateBaseFilenameInput" class="form-label">Base filename template</label>
+                                        <input id="libraryTemplateBaseFilenameInput" class="form-control" type="text">
+                                    </div>
+                                    <div class="col-md-6">
+                                        <label for="libraryTemplateUpdateFolderInput" class="form-label">Update folder template</label>
+                                        <input id="libraryTemplateUpdateFolderInput" class="form-control" type="text">
+                                    </div>
+                                    <div class="col-md-6">
+                                        <label for="libraryTemplateUpdateFilenameInput" class="form-label">Update filename template</label>
+                                        <input id="libraryTemplateUpdateFilenameInput" class="form-control" type="text">
+                                    </div>
+                                    <div class="col-md-6">
+                                        <label for="libraryTemplateDlcFolderInput" class="form-label">DLC folder template</label>
+                                        <input id="libraryTemplateDlcFolderInput" class="form-control" type="text">
+                                    </div>
+                                    <div class="col-md-6">
+                                        <label for="libraryTemplateDlcFilenameInput" class="form-label">DLC filename template</label>
+                                        <input id="libraryTemplateDlcFilenameInput" class="form-control" type="text">
+                                    </div>
+                                    <div class="col-md-6">
+                                        <label for="libraryTemplateOtherFolderInput" class="form-label">Other folder template</label>
+                                        <input id="libraryTemplateOtherFolderInput" class="form-control" type="text">
+                                    </div>
+                                    <div class="col-md-6">
+                                        <label for="libraryTemplateOtherFilenameInput" class="form-label">Other filename template</label>
+                                        <input id="libraryTemplateOtherFilenameInput" class="form-control" type="text">
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+
+                <div class="settings-panel activity-section aerofoil-card">
+                    <div class="card-body">
+                        <div class="settings-panel-header">
+                            <h5 class="card-title">Title Identification</h5>
+                            <div class="text-muted small">Metadata language, title resolution, and media cache controls.</div>
+                        </div>
+
+                        <div class="border rounded p-3 mb-3">
+                            <div class="fw-semibold mb-2">Metadata locale</div>
                             <div class="row g-3">
                                 <div class="col-md-6">
-                                    <label for="libraryTemplateBaseFolderInput" class="form-label">Base folder template</label>
-                                    <input id="libraryTemplateBaseFolderInput" class="form-control" type="text">
+                                    <label for="selectRegion" class="form-label">Library Region:</label>
+                                    <select id="selectRegion" class="form-select" aria-label="Select library region">
+                                    </select>
                                 </div>
                                 <div class="col-md-6">
-                                    <label for="libraryTemplateBaseFilenameInput" class="form-label">Base filename template</label>
-                                    <input id="libraryTemplateBaseFilenameInput" class="form-control" type="text">
+                                    <label for="selectLanguage" class="form-label">Library Language:</label>
+                                    <select id="selectLanguage" class="form-select" aria-label="Select library language">
+                                    </select>
                                 </div>
-                                <div class="col-md-6">
-                                    <label for="libraryTemplateUpdateFolderInput" class="form-label">Update folder template</label>
-                                    <input id="libraryTemplateUpdateFolderInput" class="form-control" type="text">
+                                <div id="selectRegionLanguageHelp" class="form-text">Region and Language used to get games
+                                    informations.</div>
+                            </div>
+                        </div>
+
+                        <div class="border rounded p-3 mb-3">
+                            <div class="fw-semibold mb-2">Identification tools</div>
+                            <div>
+                                <label for="consoleKeysInput" class="form-label">Console keys:</label>
+                                <div class="d-flex flex-wrap align-items-end gap-2">
+                                    <div style="width: 100%; max-width: 420px;">
+                                        <input class="form-control" type="file"
+                                            accept=".keys,.txt" id="consoleKeysInput">
+                                    </div>
+                                    <button type="button" id="uploadConsoleKeysBtn" class="btn btn-outline-primary" onClick='uploadConsoleKeys()'>
+                                        Upload / Replace keys
+                                    </button>
+                                    <button type="button" id="deleteConsoleKeysBtn" class="btn btn-outline-danger" onClick='deleteConsoleKeys()' {% if valid_keys != true %}disabled{% endif %}>
+                                        Delete keys
+                                    </button>
+                                    <span id="consoleKeysActionStatus" class="btn btn-sm btn-outline-secondary disabled" role="status" aria-live="polite"></span>
                                 </div>
-                                <div class="col-md-6">
-                                    <label for="libraryTemplateUpdateFilenameInput" class="form-label">Update filename template</label>
-                                    <input id="libraryTemplateUpdateFilenameInput" class="form-control" type="text">
-                                </div>
-                                <div class="col-md-6">
-                                    <label for="libraryTemplateDlcFolderInput" class="form-label">DLC folder template</label>
-                                    <input id="libraryTemplateDlcFolderInput" class="form-control" type="text">
-                                </div>
-                                <div class="col-md-6">
-                                    <label for="libraryTemplateDlcFilenameInput" class="form-label">DLC filename template</label>
-                                    <input id="libraryTemplateDlcFilenameInput" class="form-control" type="text">
-                                </div>
-                                <div class="col-md-6">
-                                    <label for="libraryTemplateOtherFolderInput" class="form-label">Other folder template</label>
-                                    <input id="libraryTemplateOtherFolderInput" class="form-control" type="text">
-                                </div>
-                                <div class="col-md-6">
-                                    <label for="libraryTemplateOtherFilenameInput" class="form-label">Other filename template</label>
-                                    <input id="libraryTemplateOtherFilenameInput" class="form-control" type="text">
+                                <div id="consoleKeysHelp" class="form-text">Console keys are required to decrypt any console
+                                    content, including
+                                    backups. AeroFoil uses this to identify files, regardless of the filename.
                                 </div>
                             </div>
                         </div>
-                    </div>
-                </div>
 
-                <label class="form-label">Library paths:</label>
-                <div id="libraryPathHelp" class="form-text">Path of directory containing your games.</div>
-                <table class="table table-hover caption-top" id="pathsTable">
-                    <thead>
-                        <tr>
-                            <th scope="col">Path</th>
-                            <th scope="col">Actions</th>
-                        </tr>
-                    </thead>
-                    <tbody>
-                    </tbody>
-                </table>
-
-                <!-- Library buttons -->
-                <div class="row g-3">
-                    <div class="col-auto">
-                        <button class="btn btn-primary" type="button" data-bs-toggle="collapse"
-                            data-bs-target="#collapseNewPath" aria-expanded="false" aria-controls="collapseNewPath">
-                            Add library path
-                        </button>
-                    </div>
-
-                    <div class="col-auto">
-                        <button type="button" class="btn btn-primary mb-3 scanBtn" onClick='scanLibrary()'>Scan
-                            library</button>
-                    </div>
-                </div>
-
-                <div class="collapse" id="collapseNewPath">
-                    <div class="card card-body">
-                        <label class="form-label">Add a new directory:</label>
-                        <div class="row g-3">
-                            <div class="col-6">
-                                <input type="text" class="form-control" id="libraryPathInput" placeholder="Path">
+                        <div class="border rounded p-3">
+                            <div class="fw-semibold mb-2">Media cache</div>
+                            <div class="d-flex flex-wrap align-items-center gap-3 mb-3">
+                                <button type="button" id="refreshMediaCacheBtn" class="btn btn-outline-secondary"
+                                    onClick='refreshMediaCache()'>Refresh icons and banners</button>
+                                <button type="button" id="prefetchIconsBtn" class="btn btn-outline-secondary"
+                                    onClick='prefetchAllIcons()'>Prefetch all icons</button>
+                                <button type="button" id="prefetchBannersBtn" class="btn btn-outline-secondary"
+                                    onClick='prefetchAllBanners()'>Prefetch all banners</button>
+                                <span id="refreshMediaCacheStatus" class="text-muted small"></span>
                             </div>
-                            <div class="col-auto">
-                                <button type="button" id="submitNewLibraryPathBtn" class="btn btn-primary mb-3"
-                                    onClick='submitNewLibraryPath()'>Submit</button>
+
+                            <div>
+                                <button type="button" id="submitTitlesSettingsBtn" class="btn btn-primary"
+                                    onClick='submitTitlesSettings()'>Save title settings</button>
                             </div>
                         </div>
                     </div>
@@ -283,115 +603,112 @@
                     </div>
                 </div>
 
-                <hr class="my-4">
-
-                <h3 class="pb-3">Title Identification</h3>
-                <p class="text-muted">Titles identification configuration.</p>
-                <div class="row mb-3">
-                    <div class="col">
-                        <label for="selectRegion" class="form-label">Library Region:</label>
-                        <select id="selectRegion" class="form-select" aria-label="Select library region">
-                        </select>
-                    </div>
-                    <div class="col">
-                        <label for="selectLanguage" class="form-label">Library Language:</label>
-                        <select id="selectLanguage" class="form-select" aria-label="Select library language">
-                        </select>
-                    </div>
-                    <div id="selectRegionLanguageHelp" class="form-text">Region and Language used to get games
-                        informations.</div>
-                </div>
-
-                <div class="mb-3">
-                    <label for="consoleKeysInput" class="form-label">Console keys:</label>
-                    <div class="d-flex flex-wrap align-items-end gap-2">
-                        <div style="width: 100%; max-width: 420px;">
-                            <input class="form-control" type="file"
-                                accept=".keys,.txt" id="consoleKeysInput">
+                <div class="modal fade" id="settingsNoticeModal" tabindex="-1" aria-labelledby="settingsNoticeModalLabel"
+                    aria-hidden="true">
+                    <div class="modal-dialog modal-dialog-centered">
+                        <div class="modal-content">
+                            <div class="modal-header">
+                                <h1 class="modal-title fs-5" id="settingsNoticeModalLabel">Settings notice</h1>
+                                <button type="button" class="btn-close" data-bs-dismiss="modal"
+                                    aria-label="Close"></button>
+                            </div>
+                            <div class="modal-body" id="settingsNoticeModalBody"></div>
+                            <div class="modal-footer">
+                                <button type="button" class="btn btn-primary" data-bs-dismiss="modal">Close</button>
+                            </div>
                         </div>
-                        <button type="button" id="uploadConsoleKeysBtn" class="btn btn-outline-primary" onClick='uploadConsoleKeys()'>
-                            Upload / Replace keys
-                        </button>
-                        <button type="button" id="deleteConsoleKeysBtn" class="btn btn-outline-danger" onClick='deleteConsoleKeys()' {% if valid_keys != true %}disabled{% endif %}>
-                            Delete keys
-                        </button>
-                        <span id="consoleKeysActionStatus" class="btn btn-sm btn-outline-secondary disabled" role="status" aria-live="polite"></span>
-                    </div>
-                    <div id="consoleKeysHelp" class="form-text">Console keys are required to decrypt any console
-                        content, including
-                        backups. AeroFoil uses this to identify files, regardless of the filename.
                     </div>
                 </div>
 
-                <div class="mb-3">
-                    <button type="button" id="submitTitlesSettingsBtn" class="btn btn-primary"
-                        onClick='submitTitlesSettings()'>Save title settings</button>
-                </div>
-                <div class="mb-3 d-flex align-items-center gap-3">
-                    <button type="button" id="refreshMediaCacheBtn" class="btn btn-outline-secondary"
-                        onClick='refreshMediaCache()'>Refresh icons and banners</button>
-                    <button type="button" id="prefetchIconsBtn" class="btn btn-outline-secondary"
-                        onClick='prefetchAllIcons()'>Prefetch all icons</button>
-                    <button type="button" id="prefetchBannersBtn" class="btn btn-outline-secondary"
-                        onClick='prefetchAllBanners()'>Prefetch all banners</button>
-                    <span id="refreshMediaCacheStatus" class="text-muted small"></span>
-                </div>
                 </form>
                 </div>
 
                 <!-- Shop Section -->
                 <div class="settings-section d-none" id="section-shop" data-section="shop">
-                <h2 class="pb-3">Shop</h2>
-                <!-- Shop URL -->
-                <div class="mb-3">
-                    <label for="shopHostInput" class="form-label">Shop URL:</label>
-                    <input class="form-control" id="shopHostInput" aria-describedby="shopHostHelp"
-                        placeholder="shop.domain.tld">
-                    <div id="shopHostHelp" class="form-text">Configure your shop URL to enable host verification.<br>
-                        Host verification from Tinfoil requests will be enforced if the shop is accessed securely (with
-                        <code>https</code>), make sure your reverse proxy <strong>does NOT</strong> allow insecure
-                        connections (or upgrades them to use SSL) and correctly sets the <code>X-Forwarded-Proto</code>
-                        header.
+                <div class="settings-section-header">
+                    <div class="d-flex flex-wrap align-items-start justify-content-between gap-3">
+                        <div>
+                            <h3 class="mb-1">Shop</h3>
+                            <div class="settings-section-subtitle">Connectivity, access rules, security controls, and client-facing branding.</div>
+                        </div>
                     </div>
                 </div>
-                <div class="mb-3">
-                    <label for="shopHauthInput" class="form-label">Shop Hauth:</label>
-                    <input class="form-control" id="shopHauthInput" aria-describedby="shopHauthHelp"
-                        placeholder="Hauth value">
-                    <div id="shopHauthHelp" class="form-text">Override the host signature (Hauth) used for Tinfoil verification.</div>
-                </div>
-                <div class="mb-3 form-check">
-                    <input type="checkbox" class="form-check-input" id="publicShopCheck"
-                        aria-describedby="publicShopCheckHelp">
-                    <label class="form-check-label" for="publicShopCheck">Public shop</label>
-                    <div id="publicShopCheckHelp" class="form-text">If enabled, Shop access from Tinfoil does not
-                        require authentication.
-                    </div>
-                </div>
-                <div class="mb-3 form-check">
-                    <input type="checkbox" class="form-check-input" id="externalTinfoilOnlyCheck"
-                        aria-describedby="externalTinfoilOnlyCheckHelp">
-                    <label class="form-check-label" for="externalTinfoilOnlyCheck">External access: Tinfoil/CyberFoil only</label>
-                    <div id="externalTinfoilOnlyCheckHelp" class="form-text">If enabled, requests from external/public IP addresses are allowed only for Tinfoil/CyberFoil shop clients (detected by the Tinfoil header set and/or matching <code>User-Agent</code>). Private/local network access is unchanged.</div>
-                </div>
-                <div class="mb-3 form-check">
-                    <input type="checkbox" class="form-check-input" id="encryptShopCheck"
-                        aria-describedby="encryptShopCheckHelp">
-                    <label class="form-check-label" for="encryptShopCheck">Encrypt shop</label>
-                    <div id="encryptShopCheckHelp" class="form-text">Serve encrypted and compressed shop, so that only Tinfoil clients
-                        can access the content. <strong>Strongly suggested to enable it for security</strong>.</div>
-                </div>
-                <div class="mb-3 form-check">
-                    <input type="checkbox" class="form-check-input" id="fastTransferModeCheck"
-                        aria-describedby="fastTransferModeCheckHelp">
-                    <label class="form-check-label" for="fastTransferModeCheck">Fast transfer mode</label>
-                    <div id="fastTransferModeCheckHelp" class="form-text">
-                        Prioritize throughput by skipping per-chunk transfer tracking. Activity live byte counters and exact transfer byte accounting may be less precise.
-                    </div>
-                </div>
-                <div class="card mb-3">
+                <div class="settings-panel activity-section aerofoil-card">
                     <div class="card-body">
-                        <h6 class="card-title mb-3">Login Protection</h6>
+                        <div class="settings-panel-header">
+                            <h5 class="card-title">Connectivity</h5>
+                            <div class="text-muted small">Core values used for shop routing and Tinfoil host verification.</div>
+                        </div>
+
+                        <div class="row g-3">
+                            <div class="col-lg-7">
+                                <label for="shopHostInput" class="form-label">Shop URL:</label>
+                                <input class="form-control" id="shopHostInput" aria-describedby="shopHostHelp"
+                                    placeholder="shop.domain.tld">
+                                <div id="shopHostHelp" class="form-text">Configure your shop URL to enable host verification.<br>
+                                    Host verification from Tinfoil requests will be enforced if the shop is accessed securely (with
+                                    <code>https</code>), make sure your reverse proxy <strong>does NOT</strong> allow insecure
+                                    connections (or upgrades them to use SSL) and correctly sets the <code>X-Forwarded-Proto</code>
+                                    header.
+                                </div>
+                            </div>
+                            <div class="col-lg-5">
+                                <label for="shopHauthInput" class="form-label">Shop Hauth:</label>
+                                <input class="form-control" id="shopHauthInput" aria-describedby="shopHauthHelp"
+                                    placeholder="Hauth value">
+                                <div id="shopHauthHelp" class="form-text">Override the host signature (Hauth) used for Tinfoil verification.</div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+
+                <div class="settings-panel activity-section aerofoil-card">
+                    <div class="card-body">
+                        <div class="settings-panel-header">
+                            <h5 class="card-title">Access And Delivery</h5>
+                            <div class="text-muted small">How clients reach the shop and how the content is served.</div>
+                        </div>
+
+                        <div class="settings-option-stack">
+                            <div class="form-check">
+                                <input type="checkbox" class="form-check-input" id="publicShopCheck"
+                                    aria-describedby="publicShopCheckHelp">
+                                <label class="form-check-label" for="publicShopCheck">Public shop</label>
+                                <div id="publicShopCheckHelp" class="form-text">If enabled, Shop access from Tinfoil does not
+                                    require authentication.
+                                </div>
+                            </div>
+                            <div class="form-check">
+                                <input type="checkbox" class="form-check-input" id="externalTinfoilOnlyCheck"
+                                    aria-describedby="externalTinfoilOnlyCheckHelp">
+                                <label class="form-check-label" for="externalTinfoilOnlyCheck">External access: Tinfoil/CyberFoil only</label>
+                                <div id="externalTinfoilOnlyCheckHelp" class="form-text">If enabled, requests from external/public IP addresses are allowed only for Tinfoil/CyberFoil shop clients (detected by the Tinfoil header set and/or matching <code>User-Agent</code>). Private/local network access is unchanged.</div>
+                            </div>
+                            <div class="form-check">
+                                <input type="checkbox" class="form-check-input" id="encryptShopCheck"
+                                    aria-describedby="encryptShopCheckHelp">
+                                <label class="form-check-label" for="encryptShopCheck">Encrypt shop</label>
+                                <div id="encryptShopCheckHelp" class="form-text">Serve encrypted and compressed shop, so that only Tinfoil clients
+                                    can access the content. <strong>Strongly suggested to enable it for security</strong>.</div>
+                            </div>
+                            <div class="form-check">
+                                <input type="checkbox" class="form-check-input" id="fastTransferModeCheck"
+                                    aria-describedby="fastTransferModeCheckHelp">
+                                <label class="form-check-label" for="fastTransferModeCheck">Fast transfer mode</label>
+                                <div id="fastTransferModeCheckHelp" class="form-text">
+                                    Prioritize throughput by skipping per-chunk transfer tracking. Activity live byte counters and exact transfer byte accounting may be less precise.
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+
+                <div class="settings-panel activity-section aerofoil-card">
+                    <div class="card-body">
+                        <div class="settings-panel-header">
+                            <h5 class="card-title">Login Protection</h5>
+                            <div class="text-muted small">Authentication controls for the web UI and remote shop access.</div>
+                        </div>
                         <div class="form-check form-switch mb-3">
                             <input type="checkbox" class="form-check-input" id="authIpLockoutEnabledCheck">
                             <label class="form-check-label" for="authIpLockoutEnabledCheck">Enable failed-login IP lockout</label>
@@ -419,58 +736,74 @@
                     </div>
                 </div>
 
-                <div class="mb-3">
-                    <div class="d-flex justify-content-between align-items-center mb-2">
-                        <label for="shopPublicKeyInput" class="form-label mb-0">Public Key:</label>
-                        <div class="btn-group" role="group">
-                            <button type="button" class="btn btn-sm btn-outline-secondary" data-bs-toggle="collapse" data-bs-target="#shopPublicKeyCollapse" aria-expanded="false" aria-controls="shopPublicKeyCollapse">
-                                <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" viewBox="0 0 16 16" style="vertical-align: -0.125em;">
-                                    <path fill-rule="evenodd" d="M1.646 4.646a.5.5 0 0 1 .708 0L8 10.293l5.646-5.647a.5.5 0 0 1 .708.708l-6 6a.5.5 0 0 1-.708 0l-6-6a.5.5 0 0 1 0-.708z"/>
-                                </svg>
-                                Show
-                            </button>
-                            <button type="button" class="btn btn-sm btn-outline-secondary" id="copyPublicKeyBtn" onclick="copyPublicKey()">
-                                <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" viewBox="0 0 16 16" style="vertical-align: -0.125em;">
-                                    <path d="M4 1.5H3a2 2 0 0 0-2 2V14a2 2 0 0 0 2 2h10a2 2 0 0 0 2-2V3.5a2 2 0 0 0-2-2h-1v1h1a1 1 0 0 1 1 1V14a1 1 0 0 1-1 1H3a1 1 0 0 1-1-1V3.5a1 1 0 0 1 1-1h1v-1z"/>
-                                    <path d="M9.5 1a.5.5 0 0 1 .5.5v1a.5.5 0 0 1-.5.5h-3a.5.5 0 0 1-.5-.5v-1a.5.5 0 0 1 .5-.5h3zm-3-1A1.5 1.5 0 0 0 5 1.5v1A1.5 1.5 0 0 0 6.5 4h3A1.5 1.5 0 0 0 11 2.5v-1A1.5 1.5 0 0 0 9.5 0h-3z"/>
-                                </svg>
-                                Copy
-                            </button>
+                <div class="settings-panel activity-section aerofoil-card">
+                    <div class="card-body">
+                        <div class="settings-panel-header">
+                            <h5 class="card-title">Keys And Branding</h5>
+                            <div class="text-muted small">Encryption material and the message shown to clients after loading the shop.</div>
+                        </div>
+
+                        <div class="mb-3">
+                            <div class="d-flex justify-content-between align-items-center mb-2">
+                                <label for="shopPublicKeyInput" class="form-label mb-0">Public Key:</label>
+                                <div class="btn-group" role="group">
+                                    <button type="button" class="btn btn-sm btn-outline-secondary" data-bs-toggle="collapse" data-bs-target="#shopPublicKeyCollapse" aria-expanded="false" aria-controls="shopPublicKeyCollapse">
+                                        <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" viewBox="0 0 16 16" style="vertical-align: -0.125em;">
+                                            <path fill-rule="evenodd" d="M1.646 4.646a.5.5 0 0 1 .708 0L8 10.293l5.646-5.647a.5.5 0 0 1 .708.708l-6 6a.5.5 0 0 1-.708 0l-6-6a.5.5 0 0 1 0-.708z"/>
+                                        </svg>
+                                        Show
+                                    </button>
+                                    <button type="button" class="btn btn-sm btn-outline-secondary" id="copyPublicKeyBtn" onclick="copyPublicKey()">
+                                        <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" viewBox="0 0 16 16" style="vertical-align: -0.125em;">
+                                            <path d="M4 1.5H3a2 2 0 0 0-2 2V14a2 2 0 0 0 2 2h10a2 2 0 0 0 2-2V3.5a2 2 0 0 0-2-2h-1v1h1a1 1 0 0 1 1 1V14a1 1 0 0 1-1 1H3a1 1 0 0 1-1-1V3.5a1 1 0 0 1 1-1h1v-1z"/>
+                                            <path d="M9.5 1a.5.5 0 0 1 .5.5v1a.5.5 0 0 1-.5.5h-3a.5.5 0 0 1-.5-.5v-1a.5.5 0 0 1 .5-.5h3zm-3-1A1.5 1.5 0 0 0 5 1.5v1A1.5 1.5 0 0 0 6.5 4h3A1.5 1.5 0 0 0 11 2.5v-1A1.5 1.5 0 0 0 9.5 0h-3z"/>
+                                        </svg>
+                                        Copy
+                                    </button>
+                                </div>
+                            </div>
+                            <div class="collapse" id="shopPublicKeyCollapse">
+                                <textarea class="form-control font-monospace" id="shopPublicKeyInput" rows="7"
+                                    aria-describedby="shopPublicKeyHelp" placeholder="-----BEGIN PUBLIC KEY-----"></textarea>
+                            </div>
+                            <div id="shopPublicKeyHelp" class="form-text">Public key used to encrypt the shop payload for Tinfoil clients.
+                                Changing this will break encrypted shop access unless clients have the matching private key.</div>
+                        </div>
+
+                        <div class="mb-3">
+                            <label for="motdTextArea" class="form-label">Message of the day:</label>
+                            <textarea class="form-control" id="motdTextArea" rows="3"></textarea>
+                            <div id="motdTextAreaHelp" class="form-text">Message presented when opening Tinfoil after
+                                successfully loading your shop.</div>
+                        </div>
+
+                        <div>
+                            <button type="button" id="submitShopSettingsBtn" class="btn btn-primary"
+                                onClick='submitShopSettings()'>Save shop settings</button>
                         </div>
                     </div>
-                    <div class="collapse" id="shopPublicKeyCollapse">
-                        <textarea class="form-control font-monospace" id="shopPublicKeyInput" rows="7"
-                            aria-describedby="shopPublicKeyHelp" placeholder="-----BEGIN PUBLIC KEY-----"></textarea>
-                    </div>
-                    <div id="shopPublicKeyHelp" class="form-text">Public key used to encrypt the shop payload for Tinfoil clients.
-                        Changing this will break encrypted shop access unless clients have the matching private key.</div>
-                </div>
-
-                <div class="mb-3">
-                    <label for="motdTextArea" class="form-label">Message of the day:</label>
-                    <textarea class="form-control" id="motdTextArea" rows="3"></textarea>
-                    <div id="motdTextAreaHelp" class="form-text">Message presented when opening Tinfoil after
-                        successfully loading your shop.</div>
-                </div>
-
-                <div class="mb-3">
-                    <button type="button" id="submitShopSettingsBtn" class="btn btn-primary"
-                        onClick='submitShopSettings()'>Submit</button>
                 </div>
                 </div>
 
                 <!-- Downloads Section -->
                 <div class="settings-section d-none" id="section-downloads" data-section="downloads">
-                <div class="d-flex justify-content-between align-items-center mb-3">
-                    <h2 class="mb-0">Downloads</h2>
-                    <div class="form-check">
-                        <input type="checkbox" class="form-check-input" id="downloadsEnabledCheck">
-                        <label class="form-check-label" for="downloadsEnabledCheck">Enable automatic downloads</label>
+                <div class="settings-section-header">
+                    <div class="d-flex flex-wrap align-items-start justify-content-between gap-3">
+                        <div>
+                            <h3 class="mb-1">Downloads</h3>
+                            <div class="settings-section-subtitle">Automation cadence, search tuning, and torrent or usenet client integration.</div>
+                        </div>
+                        <div class="form-check form-switch mt-1">
+                            <input type="checkbox" class="form-check-input" id="downloadsEnabledCheck">
+                            <label class="form-check-label" for="downloadsEnabledCheck">Enable automatic downloads</label>
+                        </div>
                     </div>
                 </div>
+                <div class="settings-panel activity-section aerofoil-card">
+                    <div class="card-body">
 
                 <!-- Tab navigation -->
-                <ul class="nav nav-tabs mb-3" id="downloadsTabs" role="tablist">
+                <ul class="nav nav-tabs settings-downloads-tabs" id="downloadsTabs" role="tablist">
                     <li class="nav-item" role="presentation">
                         <button class="nav-link active" id="general-tab" data-bs-toggle="tab" data-bs-target="#general" type="button" role="tab" aria-controls="general" aria-selected="true">General</button>
                     </li>
@@ -645,7 +978,9 @@
                         onClick='submitDownloadSettings()'>Save Settings</button>
                 </div>
                 </div>
+                </div>
 
+            </div>
             </div>
         </div>
     </div>
@@ -736,6 +1071,127 @@
         templates: { default: JSON.parse(JSON.stringify(DEFAULT_LIBRARY_NAMING_TEMPLATE)) }
     };
     let consoleKeysLoaded = false;
+    let settingsNoticeModal = null;
+    let settingsNoticeQueue = [];
+    let activeSettingsNoticeKey = null;
+
+    const initialSettingsFlags = {
+        adminAccountCreated: {{ 'true' if admin_account_created else 'false' }},
+    };
+
+    const SETTINGS_NOTICE_CONTENT = {
+        missingAdminAccount: {
+            title: 'Missing admin account',
+            variant: 'danger',
+            bodyHtml: `
+                <p>AeroFoil requires an admin account to enable authentication.</p>
+                <p><strong>Until an account with admin rights is created, authentication is disabled and anyone can access and change your shop configuration.</strong></p>
+                <p class="mb-0">Add an admin account from the Users page.</p>
+            `
+        },
+        missingConsoleKeys: {
+            title: 'Missing console keys',
+            variant: 'warning',
+            bodyHtml: `
+                <p>Console keys are required to decrypt console content, including backups. AeroFoil uses them to identify files regardless of filename.</p>
+                <p><strong>Titles will be missed or misidentified if you do not load your keys.</strong></p>
+                <p>See <a target="_blank" rel="noopener noreferrer" href="https://gitlab.com/easyhacking/switch/-/wikis/home/getting-started/dump-keys">this guide</a> to extract keys from your console, then upload them in Settings -> Library -> Title Identification.</p>
+                <p class="mb-0">If keys are missing, files must follow the format <code>Title Name [TITLEID][vVERSION]</code> or they will not be recognized.</p>
+            `
+        },
+        missingShopHost: {
+            title: 'Missing shop Host',
+            variant: 'warning',
+            bodyHtml: `
+                <p>Host verification from outside the local network is disabled while the shop <code>Host</code> value is empty.</p>
+                <p class="mb-0">Set it in Settings -> Shop -> Connectivity to prevent someone else stealing from your shop.</p>
+            `
+        },
+        missingShopHauth: {
+            title: 'Missing shop Hauth',
+            variant: 'warning',
+            bodyHtml: `
+                <p><a target="_blank" rel="noopener noreferrer" href="https://blawar.github.io/tinfoil/network/#host-signature">Host signature</a> verification from outside the local network is disabled while the shop <code>Hauth</code> value is missing.</p>
+                <p class="mb-0">Connect to the shop from Tinfoil with an admin account to set it.</p>
+            `
+        }
+    };
+
+    function getSettingsNoticeModal() {
+        if (!settingsNoticeModal) {
+            const modalEl = document.getElementById('settingsNoticeModal');
+            settingsNoticeModal = bootstrap.Modal.getOrCreateInstance(modalEl);
+            modalEl.addEventListener('hidden.bs.modal', function () {
+                activeSettingsNoticeKey = null;
+                showNextSettingsNotice();
+            });
+        }
+        return settingsNoticeModal;
+    }
+
+    function clearSettingsNotice(noticeKey) {
+        settingsNoticeQueue = settingsNoticeQueue.filter(function (queuedKey) {
+            return queuedKey !== noticeKey;
+        });
+
+        if (activeSettingsNoticeKey === noticeKey) {
+            getSettingsNoticeModal().hide();
+        }
+    }
+
+    function queueSettingsNotice(noticeKey) {
+        if (!SETTINGS_NOTICE_CONTENT[noticeKey]) {
+            return;
+        }
+        if (activeSettingsNoticeKey === noticeKey || settingsNoticeQueue.includes(noticeKey)) {
+            return;
+        }
+        settingsNoticeQueue.push(noticeKey);
+        showNextSettingsNotice();
+    }
+
+    function showNextSettingsNotice() {
+        if (activeSettingsNoticeKey || !settingsNoticeQueue.length) {
+            return;
+        }
+
+        const noticeKey = settingsNoticeQueue.shift();
+        const notice = SETTINGS_NOTICE_CONTENT[noticeKey];
+        if (!notice) {
+            return;
+        }
+
+        activeSettingsNoticeKey = noticeKey;
+        const modalEl = $('#settingsNoticeModal');
+        modalEl.find('.modal-title').text(notice.title);
+        modalEl.find('#settingsNoticeModalBody').html(notice.bodyHtml);
+
+        const header = modalEl.find('.modal-header');
+        header.removeClass('bg-danger-subtle border-danger-subtle bg-warning-subtle border-warning-subtle');
+        if (notice.variant === 'danger') {
+            header.addClass('bg-danger-subtle border-danger-subtle');
+        } else {
+            header.addClass('bg-warning-subtle border-warning-subtle');
+        }
+
+        getSettingsNoticeModal().show();
+    }
+
+    function syncShopSecurityNotices(shopSettings) {
+        const host = String(shopSettings?.host || '').trim();
+        const hasHauth = typeof shopSettings?.hauth === 'boolean'
+            ? shopSettings.hauth
+            : !!String(shopSettings?.hauth_value || shopSettings?.hauth || '').trim();
+
+        clearSettingsNotice('missingShopHost');
+        clearSettingsNotice('missingShopHauth');
+
+        if (!host) {
+            queueSettingsNotice('missingShopHost');
+        } else if (!hasHauth) {
+            queueSettingsNotice('missingShopHauth');
+        }
+    }
 
     function normalizeLibraryNamingTemplates(raw) {
         const fallback = {
@@ -1040,12 +1496,12 @@
         consoleKeysLoaded = !!loaded;
         const statusEl = $('#consoleKeysActionStatus');
         if (loaded) {
-            $('#missingKeysAlert').addClass('d-none');
+            clearSettingsNotice('missingConsoleKeys');
             $('#deleteConsoleKeysBtn').prop('disabled', false);
             statusEl.removeClass('btn-outline-secondary btn-danger').addClass('btn-success').text('Keys loaded');
         } else {
             $('#deleteConsoleKeysBtn').prop('disabled', true);
-            $('#missingKeysAlert').removeClass('d-none');
+            queueSettingsNotice('missingConsoleKeys');
             statusEl.removeClass('btn-outline-secondary btn-success').addClass('btn-danger').text('No keys loaded');
         }
     }
@@ -1260,6 +1716,12 @@
                         formTextElement = form.attr('aria-describedby');
                         $("#" + formTextElement).addClass('invalid-feedback');
                         $("#" + formTextElement).text(error['error']);
+                    });
+                } else {
+                    syncShopSecurityNotices({
+                        host: data['host'],
+                        hauth: !!String(data['hauth'] || '').trim(),
+                        hauth_value: data['hauth']
                     });
                 }
                 $('#submitShopSettingsBtn').prop('disabled', false);
@@ -1707,6 +2169,10 @@
     $(document).ready(function () {
         // Initialize settings navigation
         handleHashNavigation();
+        getSettingsNoticeModal();
+        if (!initialSettingsFlags.adminAccountCreated) {
+            queueSettingsNotice('missingAdminAccount');
+        }
         
         fillLibraryTable();
         $("#torrentClientTypeSelect").on("change", updateTorrentClientFieldState);
@@ -1784,11 +2250,7 @@
             setInputVal("authIpLockoutWindowInput", securitySettings['auth_ip_lockout_window_seconds'] || 600);
             setInputVal("authIpLockoutDurationInput", securitySettings['auth_ip_lockout_duration_seconds'] || 1800);
             setInputVal("authPermanentIpBlacklistInput", formatIpEntryList(securitySettings['auth_permanent_ip_blacklist'] || []));
-            if (!shopSettings['host']) {
-                $("#missingShopHostAlert").css('display', '');
-            } else if (!shopSettings['hauth']) {
-                $("#missingShopHauthAlert").css('display', '');
-            }
+            syncShopSecurityNotices(shopSettings);
 
             // Downloads settings
             downloadsSettings = result['downloads'] || {};

--- a/app/templates/upload.html
+++ b/app/templates/upload.html
@@ -9,46 +9,42 @@
                 <h2 class="pb-2">Upload</h2>
                 <p class="text-muted">Upload NSP/NSZ/XCI/XCZ files directly into the library.</p>
 
-                <div class="card mb-3">
-                    <div class="card-body">
-                        <div class="upload-panel">
-                            <div class="mb-3">
-                                <label for="uploadLibrarySelect" class="form-label">Library</label>
-                                <select class="form-select" id="uploadLibrarySelect"></select>
-                                <div class="form-text">Choose where to place your uploaded files.</div>
-                            </div>
+                <div class="upload-panel mb-3">
+                    <div class="mb-3">
+                        <label for="uploadLibrarySelect" class="form-label">Library</label>
+                        <select class="form-select" id="uploadLibrarySelect"></select>
+                        <div class="form-text">Choose where to place your uploaded files.</div>
+                    </div>
 
-                            <div class="mb-3">
-                                <label for="uploadFilesInput" class="form-label">Files</label>
-                                <div class="upload-dropzone" id="uploadDropzone">
-                                    <div class="upload-dropzone-body">
-                                        <i class="bi bi-cloud-arrow-up"></i>
-                                        <div class="upload-dropzone-title">Drag & drop files here</div>
-                                        <div class="upload-dropzone-subtitle">or click to browse</div>
-                                    </div>
-                                    <input class="form-control" type="file" id="uploadFilesInput" multiple
-                                        accept=".nsp,.nsz,.xci,.xcz">
-                                </div>
-                                <div class="form-text">Allowed: NSP, NSZ, XCI, XCZ. Large uploads may take a while.</div>
-                                <div id="uploadFileMeta" class="upload-file-meta mt-2 d-none">
-                                    <span id="uploadFileSummary"></span>
-                                    <button type="button" class="btn btn-sm btn-outline-secondary" id="uploadClearBtn">Clear list</button>
-                                </div>
-                                <div id="uploadFileList" class="upload-file-list mt-2 d-none"></div>
+                    <div class="mb-3">
+                        <label for="uploadFilesInput" class="form-label">Files</label>
+                        <div class="upload-dropzone" id="uploadDropzone">
+                            <div class="upload-dropzone-body">
+                                <i class="bi bi-cloud-arrow-up"></i>
+                                <div class="upload-dropzone-title">Drag & drop files here</div>
+                                <div class="upload-dropzone-subtitle">or click to browse</div>
                             </div>
-
-                            <div class="d-flex flex-wrap gap-2">
-                                <button type="button" id="uploadSubmitBtn" class="btn btn-primary" onClick="uploadFiles()" disabled>Upload</button>
-                                <button type="button" id="uploadResetBtn" class="btn btn-outline-secondary" onClick="resetUploadForm()">Reset</button>
-                            </div>
-
-                            <div class="mt-3">
-                                <div class="progress d-none" id="uploadProgressWrap" role="progressbar" aria-label="Upload progress">
-                                    <div class="progress-bar" id="uploadProgressBar" style="width: 0%">0%</div>
-                                </div>
-                                <div id="uploadStatus" class="text-muted small mt-2"></div>
-                            </div>
+                            <input class="form-control" type="file" id="uploadFilesInput" multiple
+                                accept=".nsp,.nsz,.xci,.xcz">
                         </div>
+                        <div class="form-text">Allowed: NSP, NSZ, XCI, XCZ. Large uploads may take a while.</div>
+                        <div id="uploadFileMeta" class="upload-file-meta mt-2 d-none">
+                            <span id="uploadFileSummary"></span>
+                            <button type="button" class="btn btn-sm btn-outline-secondary" id="uploadClearBtn">Clear list</button>
+                        </div>
+                        <div id="uploadFileList" class="upload-file-list mt-2 d-none"></div>
+                    </div>
+
+                    <div class="d-flex flex-wrap gap-2">
+                        <button type="button" id="uploadSubmitBtn" class="btn btn-primary" onClick="uploadFiles()" disabled>Upload</button>
+                        <button type="button" id="uploadResetBtn" class="btn btn-outline-secondary" onClick="resetUploadForm()">Reset</button>
+                    </div>
+
+                    <div class="mt-3">
+                        <div class="progress d-none" id="uploadProgressWrap" role="progressbar" aria-label="Upload progress">
+                            <div class="progress-bar" id="uploadProgressBar" style="width: 0%">0%</div>
+                        </div>
+                        <div id="uploadStatus" class="text-muted small mt-2"></div>
                     </div>
                 </div>
             </div>

--- a/app/templates/users.html
+++ b/app/templates/users.html
@@ -87,18 +87,29 @@
                     </div>
                 </div>
 
-                <div class="table-responsive">
-                    <table class="table table-hover align-middle" id="userTable">
-                        <thead>
-                            <tr>
-                                <th scope="col" role="button" id="usersSortUser" data-sort="user">User <span class="text-muted" id="sortUserIcon"></span></th>
-                                <th scope="col" role="button" id="usersSortPerms" data-sort="perms">Permissions <span class="text-muted" id="sortPermsIcon"></span></th>
-                                <th scope="col">Client</th>
-                                <th scope="col" class="text-end">Actions</th>
-                            </tr>
-                        </thead>
-                        <tbody></tbody>
-                    </table>
+                <div class="card mb-3 users-table-card">
+                    <div class="card-body">
+                        <div class="d-flex flex-wrap align-items-start justify-content-between gap-3 mb-3">
+                            <div>
+                                <h5 class="card-title mb-1">Accounts</h5>
+                                <div class="text-muted small">Usernames, permissions, last-seen client details, and account actions.</div>
+                            </div>
+                            <div class="text-muted small" id="usersCountLabelInline">Loading users...</div>
+                        </div>
+                        <div class="table-responsive">
+                            <table class="table table-hover align-middle users-table mb-0" id="userTable">
+                                <thead>
+                                    <tr>
+                                        <th scope="col" role="button" id="usersSortUser" data-sort="user">User <span class="text-muted" id="sortUserIcon"></span></th>
+                                        <th scope="col" role="button" id="usersSortPerms" data-sort="perms">Permissions <span class="text-muted" id="sortPermsIcon"></span></th>
+                                        <th scope="col">Client</th>
+                                        <th scope="col" class="text-end">Actions</th>
+                                    </tr>
+                                </thead>
+                                <tbody></tbody>
+                            </table>
+                        </div>
+                    </div>
                 </div>
                 <nav aria-label="Users pagination" class="mt-3">
                     <ul class="pagination justify-content-center" id="usersPagination"></ul>
@@ -232,14 +243,95 @@
 </div>
 
 <style>
+    .users-table-card .card-body {
+        padding: 1.1rem 1.1rem 1rem;
+    }
+
+    .users-table {
+        --bs-table-bg: transparent;
+        --bs-table-border-color: rgba(255, 255, 255, 0.08);
+        --bs-table-hover-bg: rgba(255, 255, 255, 0.04);
+        margin-bottom: 0;
+    }
+
+    .users-table thead th {
+        background: rgba(255, 255, 255, 0.04);
+        color: var(--bs-secondary-color);
+        font-size: 0.78rem;
+        font-weight: 600;
+        letter-spacing: 0.04em;
+        text-transform: uppercase;
+        border-bottom-width: 1px;
+        white-space: nowrap;
+    }
+
+    .users-table tbody td {
+        padding-top: 0.9rem;
+        padding-bottom: 0.9rem;
+        vertical-align: middle;
+    }
+
+    .users-table tbody tr:last-child td {
+        border-bottom: 0;
+    }
+
+    .user-name-block {
+        display: grid;
+        gap: 0.18rem;
+        min-width: 0;
+    }
+
+    .user-name-code {
+        font-size: 0.95rem;
+        color: var(--bs-body-color);
+        word-break: break-word;
+    }
+
+    .user-name-meta {
+        color: var(--bs-secondary-color);
+        font-size: 0.8rem;
+    }
+
+    .user-perms {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 0.35rem;
+    }
+
+    .user-actions {
+        display: inline-flex;
+        flex-wrap: wrap;
+        justify-content: flex-end;
+        gap: 0.35rem;
+    }
+
     .client-meta {
         display: grid;
-        gap: 0.2rem;
+        gap: 0.22rem;
         font-size: 0.82rem;
     }
 
     .client-meta code {
         font-size: 0.78rem;
+    }
+
+    .client-meta-line {
+        display: flex;
+        align-items: center;
+        gap: 0.3rem;
+        min-width: 0;
+        line-height: 1.2;
+    }
+
+    .client-meta-label {
+        color: var(--bs-secondary-color);
+        min-width: 3.9rem;
+        flex-shrink: 0;
+    }
+
+    .client-meta-value {
+        min-width: 0;
+        word-break: break-word;
     }
 
     .flag-icon {
@@ -394,6 +486,7 @@
         const pageItems = users.slice(startIdx, startIdx + pageSize);
 
         $('#usersCountLabel').text(total === 1 ? '1 user' : `${total} users`);
+        $('#usersCountLabelInline').text(total === 1 ? '1 account' : `${total} accounts`);
         _renderSortIcons();
         _renderPagination(total);
 
@@ -434,18 +527,20 @@
             const countryCode = String(user['last_login_country_code'] || '').trim().toLowerCase();
             const flagIcon = countryCode ? `<img src="https://cdn.jsdelivr.net/npm/flag-icons@7.2.3/flags/4x3/${countryCode}.svg" alt="" class="flag-icon" loading="lazy" />` : '';
             const clientMeta = [
-                `<div class="text-muted">UID: <code>${uidValue}</code></div>`,
-                `<div class="text-muted">Last login: ${_escapeHtml(lastLoginAt)}</div>`,
-                `<div class="text-muted">IP: ${lastLoginIp}</div>`,
-                `<div class="text-muted">${flagIcon}${_escapeHtml(locationLabel)}</div>`,
+                `<div class="client-meta-line"><span class="client-meta-label">UID</span><span class="client-meta-value"><code>${uidValue}</code></span></div>`,
+                `<div class="client-meta-line"><span class="client-meta-label">Login</span><span class="client-meta-value">${_escapeHtml(lastLoginAt)}</span></div>`,
+                `<div class="client-meta-line"><span class="client-meta-label">IP</span><span class="client-meta-value">${lastLoginIp}</span></div>`,
+                `<div class="client-meta-line"><span class="client-meta-label">Loc</span><span class="client-meta-value">${flagIcon}${_escapeHtml(locationLabel)}</span></div>`,
             ].join('');
             const tr = $('<tr>');
-            tr.append(`<td><code>${username}</code></td>`);
-            tr.append(`<td>${badges}</td>`);
+            tr.append(
+                `<td><div class="user-name-block"><code class="user-name-code">${username}</code><div class="user-name-meta">ID ${_escapeHtml(String(user['id']))}</div></div></td>`
+            );
+            tr.append(`<td><div class="user-perms">${badges}</div></td>`);
             tr.append(`<td><div class="client-meta">${clientMeta}</div></td>`);
             tr.append(
                 '<td class="text-end">'
-                + '<div class="d-inline-flex gap-1">'
+                + '<div class="user-actions">'
                 + '<button type="button" class="btn btn-outline-info btn-sm" data-bs-toggle="modal" data-bs-target="#editUserModal" data-bs-title="Modify user" data-bs-placement="top"'
                 + ' data-bs-id="' + user['id'] + '" data-bs-user="' + _escapeHtml(user['user']) + '"'
                 + ' data-bs-admin="' + user['admin_access'] + '" data-bs-shop="' + user['shop_access'] + '" data-bs-backup="' + user['backup_access'] + '">'
@@ -467,6 +562,7 @@
 
     function fillUserTable() {
         $('#usersCountLabel').text('Loading users...');
+        $('#usersCountLabelInline').text('Loading users...');
         $.getJSON("/api/users", function (result) {
             // Note: /api/users returns a list, not a success wrapper.
             allUsers = result || [];


### PR DESCRIPTION
## Summary

This PR refreshes the main admin/user-facing UI layout and visual system across the app.

It focuses on consistency and readability:
- applies a shared card surface/radius system across the app
- reorganizes the navbar into clearer grouped navigation
- modernizes the `Settings` and `Activity` pages with a cleaner workspace-style layout
- improves spacing, hierarchy, and table presentation on key admin pages
- cleans up redundant nested card layers introduced by the old layouts

## Main Changes

- Navbar
  - regrouped navigation into `Content`, `Backups`, and `Admin`
  - kept `Requests` top-level
  - moved `Settings` to the end
  - moved library status text to the right side near logout

- Settings
  - rebuilt the page around a sidebar + main content shell
  - reorganized `Library`, `Shop`, and `Downloads` sections for better separation
  - converted inline settings warnings into modal notices
  - simplified the `Library Paths` layout and removed unnecessary nested cards

- Activity
  - aligned the page shell and navigation styling with the new settings layout
  - preserved the flatter inner monitor/table blocks instead of inheriting rounded global card styling

- Requests
  - improved selected-title and submit-request layout
  - fixed card/body structure so the request status and admin request table align correctly

- Downloads
  - normalized page width/header spacing to match the rest of the app
  - improved queue table spacing

- Manage
  - added confirmation modals for destructive actions

- Upload
  - removed unnecessary outer card nesting so the upload panel is the single visual container

- Users
  - refreshed the users table presentation
  - improved row hierarchy, client metadata formatting, and action grouping
  - compacted the client column so rows are denser and easier to scan

## Notes

This branch is intentionally UI/layout-focused and is based on `dev`.
It does not include the separate English metadata backend feature work from `issue-71`.

## Testing

- Manual UI/layout pass recommended across:
  - `Settings`
  - `Activity`
  - `Requests`
  - `Downloads`
  - `Manage`
  - `Upload`
  - `Users`

- No dedicated automated UI test coverage was added in this PR.
