### PR TITLE
Update settings.html

### DIFF
--- a/app/templates/settings.html
+++ b/app/templates/settings.html
@@ -1089,7 +1089,7 @@
             },
             update: {
                 folder: ".",
-                filename: "{title} [{title_id}] [UPDATE][v{version}].{ext}"
+                filename: "{title} [{app_id}] [UPDATE][v{version}].{ext}"
             },
             dlc: {
                 folder: ".",
@@ -1107,7 +1107,7 @@
             },
             update: {
                 folder: "{title} [{title_id}]/Updates",
-                filename: "{title} [{title_id}] [UPDATE][v{version}].{ext}"
+                filename: "{title} [{app_id}] [UPDATE][v{version}].{ext}"
             },
             dlc: {
                 folder: "{title} [{title_id}]/DLC",


### PR DESCRIPTION
Changed title_id to app_id on updates. This prevents AeroFoil from setting the base title id on updates, which caused the application to detect multiple base files.

EDIT: actual changes are on L1092 and L1110, idk why github detected as if the whole file had changed.