### PR TITLE
fix: reflect SABnzbd failed queue states

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,6 +45,7 @@ Tests use the standard library `unittest` framework with `unittest.mock.patch`. 
 ## Commit & Pull Request Guidelines
 Match the existing history: short imperative Conventional Commit style subjects. Keep commits scoped to one change. If an issue number is given, include it in the commit msg. PRs should describe the user-visible impact, note any config or migration implications, link related issues, and include screenshots for UI/template changes. When a branch touches downloads or library management, mention protocol/client support, queue behavior, cleanup actions, and the focused unittest commands that cover the change.
 Use non-interactive Git editor flows by default. Prefer commands such as `git commit --no-edit` or explicitly setting a no-op editor instead of opening an interactive editor during rebases, merges, or other automated Git steps.
+When creating a fix branch from `upstream/dev`, do not leave the branch tracking `upstream/dev`. After branch creation, either unset the upstream or push with `-u origin <branch>` so the branch tracks its matching `origin/...` branch instead of the shared base branch.
 
 ## Security & Configuration Tips
 Do not commit secrets, `keys.txt`, or real API credentials. Prefer `AEROFOIL_*` environment variables over legacy `OWNFOIL_*` names. For production, set a strong `AEROFOIL_SECRET_KEY` and validate proxy settings before enabling trusted forwarded headers.

--- a/app/downloads/client.py
+++ b/app/downloads/client.py
@@ -9,6 +9,7 @@ from app.downloads.usenet_client import (
     add_nzb,
     list_active as list_active_usenet,
     list_completed as list_completed_usenet,
+    list_history as list_history_usenet,
     remove_history,
     remove_queue_item,
     test_sabnzbd,
@@ -125,6 +126,19 @@ def list_completed_downloads(protocol, client_cfg, timeout_seconds=15):
             timeout_seconds=timeout_seconds,
         )
     return []
+
+
+def list_history_downloads(protocol, client_cfg, timeout_seconds=15):
+    protocol = str(protocol or "").strip().lower()
+    client_type = str((client_cfg or {}).get("type") or "").strip().lower()
+    if protocol == "usenet" or client_type in USENET_CLIENT_TYPES:
+        return list_history_usenet(
+            url=(client_cfg or {}).get("url"),
+            api_key=(client_cfg or {}).get("api_key"),
+            category=(client_cfg or {}).get("category"),
+            timeout_seconds=timeout_seconds,
+        )
+    return list_completed_downloads(protocol, client_cfg, timeout_seconds=timeout_seconds)
 
 
 def remove_completed_download(protocol, client_cfg, item_id, timeout_seconds=15, delete_files=False):

--- a/app/downloads/manager.py
+++ b/app/downloads/manager.py
@@ -14,6 +14,7 @@ from app.downloads.client import (
     USENET_CLIENT_TYPES,
     list_active_downloads,
     list_completed_downloads,
+    list_history_downloads,
     queue_download,
     remove_active_download,
     remove_completed_download,
@@ -183,7 +184,7 @@ def _get_download_activity_snapshot(downloads):
             active_items = []
             protocol_errors.append(f"active: {exc}")
         try:
-            completed_items = list_completed_downloads(protocol, client_cfg)
+            completed_items = list_history_downloads(protocol, client_cfg)
         except Exception as exc:
             logger.warning("Failed to load completed %s downloads: %s", protocol, exc)
             completed_items = []
@@ -222,6 +223,28 @@ def _normalize_queue_state_label(status):
     if "seed" in text or "upload" in text:
         return "seeding"
     return text
+
+
+def _normalize_terminal_queue_state(item):
+    if isinstance(item, dict):
+        explicit_state = str(item.get("state") or "").strip().lower()
+        if explicit_state in ("completed", "failed", "cancelled"):
+            return explicit_state
+        status_text = str(item.get("status") or "").strip().lower()
+    else:
+        explicit_state = str(item or "").strip().lower()
+        if explicit_state in ("completed", "failed", "cancelled"):
+            return explicit_state
+        status_text = explicit_state
+    if not status_text:
+        return None
+    if any(token in status_text for token in ("cancel", "abort", "delete", "deleted")):
+        return "cancelled"
+    if any(token in status_text for token in ("fail", "error")):
+        return "failed"
+    if "complete" in status_text:
+        return "completed"
+    return None
 
 
 def _update_pending_live_metadata(info, item=None, status=None):
@@ -313,12 +336,22 @@ def _build_pending_queue_item(key, info, snapshot):
         _clear_pending_stuck(info)
         _update_pending_live_metadata(info, item=active_match)
         state = _normalize_queue_state_label(active_match.get("status"))
+        info["state"] = state
+        info["state_reason"] = None
     elif str(info.get("state") or "").strip().lower() == "stuck":
         state = "stuck"
         state_reason = str(info.get("state_reason") or "").strip() or "waiting for action"
     elif completed_match:
-        _update_pending_live_metadata(info, item=completed_match, status="completed")
-        state = "completed"
+        state = _normalize_terminal_queue_state(completed_match) or "completed"
+        state_reason = str(completed_match.get("state_reason") or "").strip() or None
+        _update_pending_live_metadata(info, item=completed_match, status=state)
+        info["state"] = state
+        info["state_reason"] = state_reason
+    else:
+        remembered_state = _normalize_terminal_queue_state(info)
+        if remembered_state in ("failed", "cancelled"):
+            state = remembered_state
+            state_reason = str(info.get("state_reason") or "").strip() or None
     expected_name = str(info.get("expected_name") or "").strip()
     return {
         "key": key,
@@ -487,7 +520,7 @@ def _format_pending_label(info):
 
 
 def _format_pending_display_label(info, state="queued", active_match=None, completed_match=None):
-    if not active_match or state in ("stuck", "completed"):
+    if not active_match or state in ("stuck", "completed", "failed", "cancelled"):
         for item in (completed_match, active_match):
             name = str((item or {}).get("name") or "").strip()
             if name:
@@ -1114,6 +1147,8 @@ def _infer_pending_info_from_queue_item(item):
     protocol = str(item.get("protocol") or "").strip().lower() or None
     client_type = str(item.get("client_type") or "").strip().lower() or None
     normalized_id = _normalize_pending_item_id(item.get("id") or item.get("hash"), protocol=protocol)
+    terminal_state = _normalize_terminal_queue_state(item)
+    state_reason = str(item.get("state_reason") or "").strip() or None
     info = {
         "title_id": None,
         "app_id": None,
@@ -1125,8 +1160,8 @@ def _infer_pending_info_from_queue_item(item):
         "title_name": name,
         "protocol": protocol,
         "client_type": client_type,
-        "state": "queued",
-        "state_reason": None,
+        "state": terminal_state or "queued",
+        "state_reason": state_reason,
         "last_seen_status": item.get("status") or None,
         "last_seen_path": str(item.get("path") or "").strip() or None,
     }
@@ -1155,7 +1190,7 @@ def _restore_pending_from_active(downloads):
             logger.warning("Failed to restore pending %s queue state: %s", protocol, exc)
         if protocol == "usenet":
             try:
-                queued_items.extend(list_completed_downloads(protocol, client_cfg))
+                queued_items.extend(list_history_downloads(protocol, client_cfg))
             except Exception as exc:
                 logger.warning("Failed to restore completed %s queue state: %s", protocol, exc)
 

--- a/app/downloads/usenet_client.py
+++ b/app/downloads/usenet_client.py
@@ -146,7 +146,7 @@ def list_active(url, api_key, category=None, timeout_seconds=15):
     return active
 
 
-def list_completed(url, api_key, category=None, timeout_seconds=15):
+def list_history(url, api_key, category=None, timeout_seconds=15):
     if not url or not api_key:
         return []
     try:
@@ -164,37 +164,55 @@ def list_completed(url, api_key, category=None, timeout_seconds=15):
         history.get("completed_dir")
         or payload.get("completed_dir")
     )
-    completed = []
+    history_items = []
     for item in slots:
         if not isinstance(item, dict):
             continue
         item_category = str(item.get("category") or item.get("cat") or "").strip()
         if category and item_category != category:
             continue
-        status = str(item.get("status") or "").lower()
+        status_text = str(item.get("status") or "").strip()
+        status = status_text.lower()
         completed_flag = str(item.get("completed") or "").lower()
-        if status not in ("completed", "complete") and completed_flag not in ("1", "true", "yes"):
+        terminal_state = _classify_history_terminal_state(status, completed_flag)
+        if not terminal_state:
             continue
         nzo_id = str(item.get("nzo_id") or "").strip() or None
         path = item.get("storage") or item.get("path") or item.get("downloaded_path") or ""
         path = str(path or "").strip()
         normalized_path = _normalize_completed_root(path)
-        if not normalized_path:
-            # Avoid treating the global completed_dir as a per-job path.
-            continue
+        if terminal_state == "completed":
+            if not normalized_path:
+                # Avoid treating the global completed_dir as a per-job path.
+                continue
         item_completed_dir = _normalize_completed_root(item.get("completed_dir"))
-        if normalized_path == (item_completed_dir or completed_dir):
+        if terminal_state == "completed" and normalized_path == (item_completed_dir or completed_dir):
             # Avoid treating SABnzbd's shared completed_dir as a per-job path.
             continue
-        completed.append({
+        history_items.append({
             "id": nzo_id,
             "hash": nzo_id,
             "protocol": "usenet",
             "client_type": "sabnzbd",
+            "status": status_text,
+            "state": terminal_state,
+            "state_reason": _extract_history_state_reason(item, terminal_state),
             "path": path,
             "name": item.get("name") or item.get("nzb_name") or item.get("filename") or "",
         })
-    return completed
+    return history_items
+
+
+def list_completed(url, api_key, category=None, timeout_seconds=15):
+    return [
+        item for item in list_history(
+            url,
+            api_key,
+            category=category,
+            timeout_seconds=timeout_seconds,
+        )
+        if item.get("state") == "completed"
+    ]
 
 
 def remove_history(url, api_key, item_id, timeout_seconds=15, delete_files=False):
@@ -253,6 +271,27 @@ def _normalize_completed_root(path):
         return ""
     normalized = os.path.normpath(text)
     return os.path.normcase(normalized)
+
+
+def _classify_history_terminal_state(status, completed_flag):
+    if status in ("completed", "complete") or completed_flag in ("1", "true", "yes"):
+        return "completed"
+    if any(token in status for token in ("cancel", "abort", "delete", "deleted")):
+        return "cancelled"
+    if any(token in status for token in ("fail", "error")):
+        return "failed"
+    return None
+
+
+def _extract_history_state_reason(item, terminal_state):
+    if terminal_state == "completed":
+        return None
+    for field in ("fail_message", "stage_log", "action_line"):
+        value = str((item or {}).get(field) or "").strip()
+        if value:
+            return value
+    status_text = str((item or {}).get("status") or "").strip()
+    return status_text or None
 
 
 def _sab_request(base_url, api_key, mode, timeout_seconds=15, **params):

--- a/app/templates/downloads.html
+++ b/app/templates/downloads.html
@@ -175,7 +175,15 @@
                 row.append($('<td class="small"></td>').text((item['label'] || 'Manual download').toString()));
                 row.append($('<td class="small text-muted"></td>').text((item['protocol'] || '-').toString()));
                 row.append($('<td class="small text-muted"></td>').text((item['client_type'] || '-').toString()));
-                row.append($('<td class="small"></td>').text(formatQueueState(item)));
+                const stateText = formatQueueState(item);
+                const stateCell = $('<td class="small"></td>').text(stateText);
+                const stateReason = String(item?.state_reason || '').replace(/\s+/g, ' ').trim();
+                if (stateReason) {
+                    stateCell.attr('title', stateReason);
+                    stateCell.attr('aria-label', `${stateText}: ${stateReason}`);
+                    stateCell.css('cursor', 'help');
+                }
+                row.append(stateCell);
                 const actionCell = $('<td class="small"></td>');
                 const deleteButton = $('<button type="button" class="btn btn-outline-danger btn-sm"></button>').text('Delete');
                 deleteButton.prop('disabled', !item['deletable']);

--- a/tests/test_download_clients.py
+++ b/tests/test_download_clients.py
@@ -29,7 +29,7 @@ from app.downloads.manager import (
     sort_download_search_results,
 )
 from app.downloads.prowlarr import _normalize_result
-from app.downloads.usenet_client import add_nzb, list_active, list_completed, remove_history, remove_queue_item
+from app.downloads.usenet_client import add_nzb, list_active, list_completed, list_history, remove_history, remove_queue_item
 from app.downloads.usenet_client import _restrict_job_to_matching_update_files
 
 
@@ -576,7 +576,7 @@ class QueueRoutingTests(unittest.TestCase):
         self.assertEqual(state["pending"][0]["protocol"], "torrent")
 
     @patch("app.downloads.manager._infer_pending_info_from_queue_item")
-    @patch("app.downloads.manager.list_completed_downloads")
+    @patch("app.downloads.manager.list_history_downloads")
     @patch("app.downloads.manager.list_active_downloads", return_value=[])
     @patch("app.downloads.manager._get_completed_poll_targets")
     @patch("app.downloads.manager.load_settings")
@@ -593,7 +593,7 @@ class QueueRoutingTests(unittest.TestCase):
         load_settings_mock,
         poll_targets_mock,
         list_active_mock,
-        list_completed_mock,
+        list_history_mock,
         infer_pending_mock,
     ):
         load_settings_mock.return_value = {
@@ -607,7 +607,7 @@ class QueueRoutingTests(unittest.TestCase):
             }
         }
         poll_targets_mock.return_value = [("usenet", {"type": "sabnzbd", "category": "aerofoil"})]
-        list_completed_mock.return_value = [{
+        list_history_mock.return_value = [{
             "id": "nzo123",
             "hash": "nzo123",
             "protocol": "usenet",
@@ -659,7 +659,7 @@ class QueueRoutingTests(unittest.TestCase):
         load_settings_mock,
         poll_targets_mock,
         list_active_mock,
-        list_completed_mock,
+        list_history_mock,
         infer_pending_mock,
     ):
         load_settings_mock.return_value = {
@@ -672,7 +672,7 @@ class QueueRoutingTests(unittest.TestCase):
             }
         }
         poll_targets_mock.return_value = [("torrent", {"type": "qbittorrent", "category": "aerofoil"})]
-        list_completed_mock.return_value = [{
+        list_history_mock.return_value = [{
             "id": "ABC123",
             "hash": "ABC123",
             "protocol": "torrent",
@@ -687,7 +687,7 @@ class QueueRoutingTests(unittest.TestCase):
         infer_pending_mock.assert_not_called()
 
     @patch("app.downloads.manager._infer_pending_info_from_queue_item")
-    @patch("app.downloads.manager.list_completed_downloads")
+    @patch("app.downloads.manager.list_history_downloads")
     @patch("app.downloads.manager.list_active_downloads", return_value=[])
     @patch("app.downloads.manager._get_completed_poll_targets")
     @patch("app.downloads.manager.load_settings")
@@ -705,7 +705,7 @@ class QueueRoutingTests(unittest.TestCase):
         load_settings_mock,
         poll_targets_mock,
         list_active_mock,
-        list_completed_mock,
+        list_history_mock,
         infer_pending_mock,
     ):
         load_settings_mock.return_value = {
@@ -719,7 +719,7 @@ class QueueRoutingTests(unittest.TestCase):
             }
         }
         poll_targets_mock.return_value = [("usenet", {"type": "sabnzbd", "category": "aerofoil"})]
-        list_completed_mock.return_value = [{
+        list_history_mock.return_value = [{
             "id": "nzo123",
             "hash": "nzo123",
             "protocol": "usenet",
@@ -733,7 +733,7 @@ class QueueRoutingTests(unittest.TestCase):
         self.assertEqual(state["pending"], [])
         infer_pending_mock.assert_not_called()
 
-    @patch("app.downloads.manager.list_completed_downloads")
+    @patch("app.downloads.manager.list_history_downloads")
     @patch("app.downloads.manager.list_active_downloads", return_value=[])
     @patch("app.downloads.manager._get_completed_poll_targets")
     @patch("app.downloads.manager.load_settings")
@@ -765,7 +765,7 @@ class QueueRoutingTests(unittest.TestCase):
         load_settings_mock,
         poll_targets_mock,
         list_active_mock,
-        list_completed_mock,
+        list_history_mock,
     ):
         load_settings_mock.return_value = {
             "downloads": {
@@ -778,7 +778,7 @@ class QueueRoutingTests(unittest.TestCase):
             }
         }
         poll_targets_mock.return_value = [("usenet", {"type": "sabnzbd", "category": "aerofoil"})]
-        list_completed_mock.return_value = [{
+        list_history_mock.return_value = [{
             "id": "nzo123",
             "hash": "nzo123",
             "protocol": "usenet",
@@ -791,7 +791,70 @@ class QueueRoutingTests(unittest.TestCase):
 
         self.assertEqual(state["pending"][0]["label"], "Example Release NSW-GRP")
 
-    @patch("app.downloads.manager.list_completed_downloads", return_value=[])
+    @patch("app.downloads.manager.list_history_downloads")
+    @patch("app.downloads.manager.list_active_downloads", return_value=[])
+    @patch("app.downloads.manager._get_completed_poll_targets")
+    @patch("app.downloads.manager.load_settings")
+    @patch("app.downloads.manager._state_lock")
+    @patch("app.downloads.manager._state", {
+        "running": False,
+        "last_run": 123.0,
+        "pending": {
+            "0100000000010000:123": {
+                "title_id": "0100000000010000",
+                "version": 123,
+                "hash": "nzo123",
+                "id": "nzo123",
+                "expected_name": "Example Failed Release",
+                "title_name": "Example Title",
+                "protocol": "usenet",
+                "client_type": "sabnzbd",
+                "state": "queued",
+                "state_reason": None,
+                "last_seen_status": None,
+                "last_seen_path": None,
+            }
+        },
+        "completed": set(),
+    })
+    def test_get_downloads_state_marks_sab_failed_history_items_as_failed(
+        self,
+        _state_lock_mock,
+        load_settings_mock,
+        poll_targets_mock,
+        list_active_mock,
+        list_history_mock,
+    ):
+        load_settings_mock.return_value = {
+            "downloads": {
+                "usenet_client": {
+                    "type": "sabnzbd",
+                    "url": "http://sab.local",
+                    "api_key": "secret",
+                    "category": "aerofoil",
+                }
+            }
+        }
+        poll_targets_mock.return_value = [("usenet", {"type": "sabnzbd", "category": "aerofoil"})]
+        list_history_mock.return_value = [{
+            "id": "nzo123",
+            "hash": "nzo123",
+            "protocol": "usenet",
+            "client_type": "sabnzbd",
+            "name": "Example Failed Release",
+            "status": "Failed",
+            "state": "failed",
+            "state_reason": "Unpack failed",
+            "path": "",
+        }]
+
+        state = get_downloads_state()
+
+        self.assertEqual(state["pending"][0]["state"], "failed")
+        self.assertEqual(state["pending"][0]["state_reason"], "Unpack failed")
+        self.assertEqual(state["pending"][0]["label"], "Example Failed Release")
+
+    @patch("app.downloads.manager.list_history_downloads", return_value=[])
     @patch("app.downloads.manager.list_active_downloads", return_value=[])
     @patch("app.downloads.manager._get_completed_poll_targets")
     @patch("app.downloads.manager.load_settings")
@@ -823,7 +886,7 @@ class QueueRoutingTests(unittest.TestCase):
         load_settings_mock,
         poll_targets_mock,
         list_active_mock,
-        list_completed_mock,
+        list_history_mock,
     ):
         load_settings_mock.return_value = {
             "downloads": {
@@ -1079,6 +1142,55 @@ class SabSelectionTests(unittest.TestCase):
 
         self.assertEqual(len(items), 1)
         self.assertEqual(items[0]["path"], "D:\\Downloads\\Complete\\Example Release")
+
+    @patch("app.downloads.usenet_client._sab_request")
+    def test_list_completed_can_include_failed_history_rows_for_queue_state(self, sab_request_mock):
+        sab_request_mock.return_value = {
+            "history": {
+                "completed_dir": "D:\\Downloads\\Complete",
+                "slots": [
+                    {
+                        "nzo_id": "nzo789",
+                        "status": "Failed",
+                        "category": "aerofoil",
+                        "storage": "",
+                        "name": "Example Failed Release",
+                        "fail_message": "Unpack failed",
+                    }
+                ],
+            }
+        }
+
+        items = list_history(
+            "http://sab.local",
+            "secret",
+            category="aerofoil",
+        )
+
+        self.assertEqual(len(items), 1)
+        self.assertEqual(items[0]["id"], "nzo789")
+        self.assertEqual(items[0]["state"], "failed")
+        self.assertEqual(items[0]["state_reason"], "Unpack failed")
+
+    @patch("app.downloads.usenet_client._sab_request")
+    def test_list_completed_excludes_failed_history_rows_by_default(self, sab_request_mock):
+        sab_request_mock.return_value = {
+            "history": {
+                "completed_dir": "D:\\Downloads\\Complete",
+                "slots": [
+                    {
+                        "nzo_id": "nzo789",
+                        "status": "Failed",
+                        "category": "aerofoil",
+                        "name": "Example Failed Release",
+                    }
+                ],
+            }
+        }
+
+        items = list_completed("http://sab.local", "secret", category="aerofoil")
+
+        self.assertEqual(items, [])
 
 
 class DownloadRemovalRoutingTests(unittest.TestCase):


### PR DESCRIPTION
## Summary
- classify SABnzbd history rows as completed, failed, or cancelled instead of falling back to queued
- use SAB history for queue-state reconstruction while keeping completed-import handling restricted to real completions
- show queue state reasons as a tooltip on the downloads page and document fix-branch upstream tracking in AGENTS

## Testing
- python -m unittest tests.test_download_clients