### PR TITLE
fix: prefer newer versions in duplicate cleanup

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -4281,7 +4281,7 @@ def manage_organize_library():
     dry_run = bool(data.get('dry_run', False))
     verbose = bool(data.get('verbose', False))
     results = organize_library(dry_run=dry_run, verbose=verbose)
-    if results.get('success') and not dry_run:
+    if not dry_run and results.get('mutated'):
         post_library_change()
     return jsonify(results)
 
@@ -4292,7 +4292,7 @@ def manage_delete_updates():
     dry_run = bool(data.get('dry_run', False))
     verbose = bool(data.get('verbose', False))
     results = delete_older_updates(dry_run=dry_run, verbose=verbose)
-    if results.get('success') and not dry_run:
+    if not dry_run and results.get('mutated'):
         post_library_change()
     return jsonify(results)
 
@@ -4303,7 +4303,7 @@ def manage_delete_duplicates():
     dry_run = bool(data.get('dry_run', False))
     verbose = bool(data.get('verbose', False))
     results = delete_duplicates(dry_run=dry_run, verbose=verbose)
-    if results.get('success') and not dry_run:
+    if not dry_run and results.get('mutated'):
         post_library_change()
     return jsonify(results)
 
@@ -4405,7 +4405,7 @@ def manage_convert_nsz():
         threads=threads,
         verify=verify
     )
-    if results.get('success') and not dry_run:
+    if not dry_run and results.get('mutated'):
         post_library_change()
     return jsonify(results)
 
@@ -4438,7 +4438,7 @@ def manage_convert_single():
         threads=threads,
         verify=verify
     )
-    if results.get('success') and not dry_run:
+    if not dry_run and results.get('mutated'):
         post_library_change()
     return jsonify(results)
 
@@ -4488,7 +4488,7 @@ def manage_convert_job():
                     'details': []
                 }
             _job_finish(job_id, results)
-            if results.get('success') and not dry_run:
+            if not dry_run and results.get('mutated'):
                 try:
                     post_library_change()
                 except Exception:
@@ -4545,7 +4545,7 @@ def manage_convert_single_job():
                     'details': []
                 }
             _job_finish(job_id, results)
-            if results.get('success') and not dry_run:
+            if not dry_run and results.get('mutated'):
                 try:
                     post_library_change()
                 except Exception:

--- a/app/library.py
+++ b/app/library.py
@@ -2245,7 +2245,19 @@ def delete_duplicates(dry_run=False, verbose=False, detail_limit=200):
             results['details'].append(message)
             detail_count += 1
 
-    def file_rank(file_entry):
+    def _filename_duplicate_rank(app, file_entry):
+        filename = os.path.basename(str(getattr(file_entry, 'filepath', '') or ''))
+        if filename.lower().endswith('.hdf'):
+            filename = filename[:-4]
+        detected_app_id = str(titles_lib.get_app_id_from_filename(filename) or '').strip().upper()
+        detected_version = _safe_int(titles_lib.get_version_from_filename(filename), default=-1)
+        current_app_id = str(getattr(app, 'app_id', '') or '').strip().upper()
+        app_id_matches = 1 if not detected_app_id or detected_app_id == current_app_id else 0
+        version_rank = detected_version if detected_version >= 0 else _safe_int(getattr(app, 'app_version', 0))
+        return app_id_matches, version_rank
+
+    def file_rank(app, file_entry):
+        app_id_matches, version_rank = _filename_duplicate_rank(app, file_entry)
         ext = str(file_entry.extension or '').strip().lower()
         ext_priority = {
             'nsz': 5,
@@ -2259,7 +2271,7 @@ def delete_duplicates(dry_run=False, verbose=False, detail_limit=200):
                 mtime = int(os.path.getmtime(file_entry.filepath))
         except Exception:
             mtime = 0
-        return (ext_priority, mtime, _safe_int(file_entry.size), _safe_int(file_entry.id))
+        return (app_id_matches, version_rank, ext_priority, mtime, _safe_int(file_entry.size), _safe_int(file_entry.id))
 
     apps = Apps.query.filter(Apps.owned.is_(True)).all()
     for app in apps:
@@ -2267,7 +2279,7 @@ def delete_duplicates(dry_run=False, verbose=False, detail_limit=200):
         if len(app_files_list) <= 1:
             continue
 
-        ordered = sorted(app_files_list, key=file_rank, reverse=True)
+        ordered = sorted(app_files_list, key=lambda file_entry: file_rank(app, file_entry), reverse=True)
         keeper = ordered[0]
         duplicates = ordered[1:]
         add_detail(

--- a/app/library.py
+++ b/app/library.py
@@ -1612,6 +1612,7 @@ def organize_library(dry_run=False, verbose=False, detail_limit=200):
         'skipped': 0,
         'folders_deleted': 0,
         'folders_failed': 0,
+        'mutated': False,
         'errors': [],
         'details': []
     }
@@ -1751,10 +1752,12 @@ def organize_library(dry_run=False, verbose=False, detail_limit=200):
                                 app.owned = len(app.files) > 0
                             db.session.delete(file_entry)
                             db.session.commit()
+                            results['mutated'] = True
                         else:
                             update_file_path(library_path, old_path, dest_path)
                         if os.path.exists(old_path) and os.path.normpath(old_path) != os.path.normpath(dest_path):
                             os.remove(old_path)
+                            results['mutated'] = True
                         results['skipped'] += 1
                         add_detail(f"Skip duplicate; kept existing: {dest_path}.")
                         continue
@@ -1767,6 +1770,7 @@ def organize_library(dry_run=False, verbose=False, detail_limit=200):
                         shutil.move(old_path, dest_path)
                         update_file_path(library_path, old_path, dest_path)
                         results['moved'] += 1
+                        results['mutated'] = True
                         add_detail(f"Moved: {old_path} -> {dest_path}.")
                     except Exception as e:
                         logger.error(f"Failed to move {file_entry.filepath}: {e}")
@@ -1797,6 +1801,7 @@ def organize_library(dry_run=False, verbose=False, detail_limit=200):
                 try:
                     os.rmdir(d)
                     results['folders_deleted'] += 1
+                    results['mutated'] = True
                     add_detail(f"Deleted empty folder: {d}.")
                 except OSError:
                     results['folders_failed'] += 1
@@ -2311,6 +2316,7 @@ def delete_duplicates(dry_run=False, verbose=False, detail_limit=200):
                 if dup_filepath:
                     delete_file_by_filepath(dup_filepath)
                 results['deleted'] += 1
+                results['mutated'] = True
                 add_detail(
                     f"Deleted duplicate {app.app_id} v{app.app_version}: "
                     f"{dup_filepath} (ext={dup_ext}, size={dup_size})."
@@ -2331,6 +2337,7 @@ def convert_to_nsz(command_template, delete_original=True, dry_run=False, verbos
         'success': True,
         'converted': 0,
         'skipped': 0,
+        'mutated': False,
         'errors': [],
         'details': []
     }
@@ -2530,6 +2537,7 @@ def convert_to_nsz(command_template, delete_original=True, dry_run=False, verbos
                     app.owned = True
                 _sync_apps_owned_flags(app_ids=[app.id for app in source_apps if app and app.id is not None])
                 db.session.commit()
+                results['mutated'] = True
                 add_detail(f"Converted and replaced: {old_path} -> {output_file}.")
             else:
                 library_path = get_library_path(source_library_id)
@@ -2545,6 +2553,7 @@ def convert_to_nsz(command_template, delete_original=True, dry_run=False, verbos
                         app.owned = True
                     _sync_apps_owned_flags(app_ids=[app.id for app in source_apps if app and app.id is not None])
                     db.session.commit()
+                    results['mutated'] = True
                     add_detail(f"Converted output already indexed: {output_file}.")
                 else:
                     new_file = Files(
@@ -2569,6 +2578,7 @@ def convert_to_nsz(command_template, delete_original=True, dry_run=False, verbos
                         app.owned = True
                     _sync_apps_owned_flags(app_ids=[app.id for app in source_apps if app and app.id is not None])
                     db.session.commit()
+                    results['mutated'] = True
                     add_detail(f"Converted: {source_path} -> {output_file}.")
 
             results['converted'] += 1
@@ -2613,6 +2623,7 @@ def convert_single_to_nsz(file_id, command_template, delete_original=True, dry_r
         'success': True,
         'converted': 0,
         'skipped': 0,
+        'mutated': False,
         'errors': [],
         'details': []
     }
@@ -2788,6 +2799,7 @@ def convert_single_to_nsz(file_id, command_template, delete_original=True, dry_r
                 app.owned = True
             _sync_apps_owned_flags(app_ids=[app.id for app in source_apps if app and app.id is not None])
             db.session.commit()
+            results['mutated'] = True
             if verbose:
                 results['details'].append(f"Converted and replaced: {old_path} -> {output_file}.")
         else:
@@ -2804,6 +2816,7 @@ def convert_single_to_nsz(file_id, command_template, delete_original=True, dry_r
                     app.owned = True
                 _sync_apps_owned_flags(app_ids=[app.id for app in source_apps if app and app.id is not None])
                 db.session.commit()
+                results['mutated'] = True
                 if verbose:
                     results['details'].append(f"Converted output already indexed: {output_file}.")
             else:
@@ -2829,6 +2842,7 @@ def convert_single_to_nsz(file_id, command_template, delete_original=True, dry_r
                     app.owned = True
                 _sync_apps_owned_flags(app_ids=[app.id for app in source_apps if app and app.id is not None])
                 db.session.commit()
+                results['mutated'] = True
             if verbose:
                 results['details'].append(f"Converted: {source_path} -> {output_file}.")
 

--- a/tests/test_library_helpers.py
+++ b/tests/test_library_helpers.py
@@ -373,6 +373,70 @@ class LibraryHelperTests(unittest.TestCase):
         self.assertEqual(payload["skipped"], 0)
         self.assertFalse(any(line.startswith("Skip ") for line in payload["details"]))
 
+    @patch("app.library.os.path.getmtime")
+    @patch("app.library.os.path.exists", return_value=True)
+    @patch("app.library.Apps")
+    def test_delete_duplicates_prefers_newer_detected_version_over_extension_priority(
+        self,
+        apps_mock,
+        exists_mock,
+        getmtime_mock,
+    ):
+        app = self._make_app(1, "0100AAAA00000800", "UPDATE", 131072)
+        older_file = self._make_file(101, "X:\\library\\Example Title [0100AAAA00000800] [v65536].nsz", [app])
+        older_file.extension = "nsz"
+        older_file.size = 500
+        newer_file = self._make_file(102, "X:\\library\\Example Title [0100AAAA00000800] [v131072].nsp", [app])
+        newer_file.extension = "nsp"
+        newer_file.size = 400
+        app.files = [older_file, newer_file]
+
+        apps_mock.owned.is_.return_value = True
+        apps_mock.query.filter.return_value.all.return_value = [app]
+        getmtime_mock.side_effect = lambda path: {
+            older_file.filepath: 200,
+            newer_file.filepath: 100,
+        }[path]
+
+        result = delete_duplicates(dry_run=True, verbose=True)
+
+        self.assertTrue(result["success"])
+        self.assertEqual(result["deleted"], 1)
+        self.assertIn(newer_file.filepath, result["details"][0])
+        self.assertIn(older_file.filepath, result["details"][1])
+
+    @patch("app.library.os.path.getmtime")
+    @patch("app.library.os.path.exists", return_value=True)
+    @patch("app.library.Apps")
+    def test_delete_duplicates_falls_back_to_extension_priority_without_version_tokens(
+        self,
+        apps_mock,
+        exists_mock,
+        getmtime_mock,
+    ):
+        app = self._make_app(1, "0100BBBB00000800", "UPDATE", 0)
+        preferred_file = self._make_file(201, "X:\\library\\Example Preferred [0100BBBB00000800].nsz", [app])
+        preferred_file.extension = "nsz"
+        preferred_file.size = 300
+        other_file = self._make_file(202, "X:\\library\\Example Other [0100BBBB00000800].nsp", [app])
+        other_file.extension = "nsp"
+        other_file.size = 400
+        app.files = [preferred_file, other_file]
+
+        apps_mock.owned.is_.return_value = True
+        apps_mock.query.filter.return_value.all.return_value = [app]
+        getmtime_mock.side_effect = lambda path: {
+            preferred_file.filepath: 100,
+            other_file.filepath: 200,
+        }[path]
+
+        result = delete_duplicates(dry_run=True, verbose=True)
+
+        self.assertTrue(result["success"])
+        self.assertEqual(result["deleted"], 1)
+        self.assertIn(preferred_file.filepath, result["details"][0])
+        self.assertIn(other_file.filepath, result["details"][1])
+
     def test_manage_delete_orphaned_addons_api_does_not_report_skipped_items(self):
         fake_user = self._AdminUser()
 

--- a/tests/test_library_helpers.py
+++ b/tests/test_library_helpers.py
@@ -355,6 +355,30 @@ class LibraryHelperTests(unittest.TestCase):
         self.assertEqual(payload["skipped"], 0)
         self.assertEqual(payload["details"], ["Deleted: X:\\library\\old-update.nsp."])
 
+    @patch("app.app.post_library_change")
+    @patch("app.app.delete_older_updates")
+    def test_manage_delete_updates_runs_post_change_when_mutated_despite_errors(
+        self,
+        delete_updates_mock,
+        post_library_change_mock,
+    ):
+        delete_updates_mock.return_value = {
+            "success": False,
+            "deleted": 1,
+            "skipped": 0,
+            "mutated": True,
+            "details": ["Deleted: X:\\library\\old-update.nsp."],
+            "errors": ["one file failed"],
+        }
+
+        with flask_app.test_request_context("/api/manage/delete-updates", method="POST", json={}):
+            from app.app import manage_delete_updates
+            response = manage_delete_updates.__wrapped__()
+
+        payload = response.get_json()
+        self.assertFalse(payload["success"])
+        post_library_change_mock.assert_called_once_with()
+
     def test_manage_delete_duplicates_api_does_not_report_skipped_items(self):
         fake_user = self._AdminUser()
 
@@ -372,6 +396,30 @@ class LibraryHelperTests(unittest.TestCase):
         self.assertEqual(payload["deleted"], 1)
         self.assertEqual(payload["skipped"], 0)
         self.assertFalse(any(line.startswith("Skip ") for line in payload["details"]))
+
+    @patch("app.app.post_library_change")
+    @patch("app.app.delete_duplicates")
+    def test_manage_delete_duplicates_runs_post_change_when_mutated_despite_errors(
+        self,
+        delete_duplicates_mock,
+        post_library_change_mock,
+    ):
+        delete_duplicates_mock.return_value = {
+            "success": False,
+            "deleted": 1,
+            "skipped": 0,
+            "mutated": True,
+            "details": ["Deleted duplicate 0100DUPES0000000 v1: X:\\library\\duplicate.nsp."],
+            "errors": ["cleanup failed"],
+        }
+
+        with flask_app.test_request_context("/api/manage/delete-duplicates", method="POST", json={}):
+            from app.app import manage_delete_duplicates
+            response = manage_delete_duplicates.__wrapped__()
+
+        payload = response.get_json()
+        self.assertFalse(payload["success"])
+        post_library_change_mock.assert_called_once_with()
 
     @patch("app.library.os.path.getmtime")
     @patch("app.library.os.path.exists", return_value=True)
@@ -634,6 +682,77 @@ class LibraryHelperTests(unittest.TestCase):
         self.assertEqual(status_code, 400)
         self.assertFalse(response.get_json()["success"])
         run_post_library_change_mock.assert_not_called()
+
+    @patch("app.app.post_library_change")
+    @patch("app.app.organize_library")
+    def test_manage_organize_library_runs_post_change_when_mutated_despite_errors(
+        self,
+        organize_library_mock,
+        post_library_change_mock,
+    ):
+        organize_library_mock.return_value = {
+            "success": False,
+            "moved": 2,
+            "skipped": 0,
+            "folders_deleted": 0,
+            "folders_failed": 0,
+            "mutated": True,
+            "errors": ["one file failed"],
+            "details": [],
+        }
+
+        with flask_app.test_request_context("/api/manage/organize", method="POST", json={}):
+            from app.app import manage_organize_library
+            response = manage_organize_library.__wrapped__()
+
+        self.assertFalse(response.get_json()["success"])
+        post_library_change_mock.assert_called_once_with()
+
+    @patch("app.app.post_library_change")
+    @patch("app.app.convert_to_nsz")
+    def test_manage_convert_nsz_runs_post_change_when_mutated_despite_errors(
+        self,
+        convert_mock,
+        post_library_change_mock,
+    ):
+        convert_mock.return_value = {
+            "success": False,
+            "converted": 1,
+            "skipped": 0,
+            "mutated": True,
+            "errors": ["one file failed"],
+            "details": [],
+        }
+
+        with flask_app.test_request_context("/api/manage/convert", method="POST", json={"command": "nsz"}):
+            from app.app import manage_convert_nsz
+            response = manage_convert_nsz.__wrapped__()
+
+        self.assertFalse(response.get_json()["success"])
+        post_library_change_mock.assert_called_once_with()
+
+    @patch("app.app.post_library_change")
+    @patch("app.app.convert_single_to_nsz")
+    def test_manage_convert_single_runs_post_change_when_mutated_despite_errors(
+        self,
+        convert_single_mock,
+        post_library_change_mock,
+    ):
+        convert_single_mock.return_value = {
+            "success": False,
+            "converted": 1,
+            "skipped": 0,
+            "mutated": True,
+            "errors": ["verify failed after write"],
+            "details": [],
+        }
+
+        with flask_app.test_request_context("/api/manage/convert-single", method="POST", json={"file_id": 1, "command": "nsz"}):
+            from app.app import manage_convert_single
+            response = manage_convert_single.__wrapped__()
+
+        self.assertFalse(response.get_json()["success"])
+        post_library_change_mock.assert_called_once_with()
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary
This fixes duplicate cleanup so update files are not kept or deleted purely by container preference when their detected versions differ.

## Changes
- prefer the newer detected filename version when choosing which duplicate file to keep
- still prefer files that match the current app id before comparing format/mtime/size
- keep the previous extension-based fallback when version tokens are missing
- refresh derived library state after partial-success manage actions that already mutated files

## Why
`delete older updates` was already version-based, but `delete duplicates` was ranking by file type, modified time, and size. That could delete a newer update file if an older file had a more preferred extension.

While tracing that path, I also found that several manage endpoints only ran `post_library_change()` on overall success even though the helpers commit work incrementally. That could leave state stale after partial-success organize/convert/delete runs.

## Verification
- `python -m unittest tests.test_library_helpers`