### PR TITLE
fix: support semantic update version matching (#87)

### DIFF
--- a/app/downloads/client.py
+++ b/app/downloads/client.py
@@ -17,6 +17,48 @@ from app.downloads.usenet_client import (
 
 TORRENT_CLIENT_TYPES = {"qbittorrent", "transmission", "deluge"}
 USENET_CLIENT_TYPES = {"sabnzbd"}
+DOWNLOAD_QUEUE_OPTION_KEYS = (
+    "expected_name",
+    "expected_update_number",
+    "expected_version",
+)
+
+
+def _normalize_protocol_and_type(protocol, client_cfg):
+    return (
+        str(protocol or "").strip().lower(),
+        str((client_cfg or {}).get("type") or "").strip().lower(),
+    )
+
+
+def _is_torrent_client(protocol, client_type):
+    return protocol == "torrent" or client_type in TORRENT_CLIENT_TYPES
+
+
+def _is_usenet_client(protocol, client_type):
+    return protocol == "usenet" or client_type in USENET_CLIENT_TYPES
+
+
+def _get_common_client_kwargs(client_cfg):
+    config = client_cfg or {}
+    return {
+        "url": config.get("url"),
+        "username": config.get("username"),
+        "password": config.get("password"),
+        "api_key": config.get("api_key"),
+        "category": config.get("category"),
+        "download_path": config.get("download_path"),
+    }
+
+
+def _get_queue_download_options(kwargs):
+    options = {
+        "update_only": bool(kwargs.get("update_only")),
+        "exclude_russian": bool(kwargs.get("exclude_russian")),
+    }
+    for key in DOWNLOAD_QUEUE_OPTION_KEYS:
+        options[key] = kwargs.get(key)
+    return options
 
 
 def test_download_client(client_type, url, username=None, password=None, api_key=None, timeout_seconds=10):
@@ -39,111 +81,104 @@ def test_download_client(client_type, url, username=None, password=None, api_key
 
 
 def queue_download(protocol, client_cfg, download_url, timeout_seconds=15, **kwargs):
-    protocol = str(protocol or "").strip().lower()
-    client_type = str((client_cfg or {}).get("type") or "").strip().lower()
-    if protocol == "torrent" or client_type in TORRENT_CLIENT_TYPES:
+    protocol, client_type = _normalize_protocol_and_type(protocol, client_cfg)
+    common_kwargs = _get_common_client_kwargs(client_cfg)
+    queue_options = _get_queue_download_options(kwargs)
+    if _is_torrent_client(protocol, client_type):
         return add_torrent(
             client_type=client_type,
-            url=(client_cfg or {}).get("url"),
-            username=(client_cfg or {}).get("username"),
-            password=(client_cfg or {}).get("password"),
+            url=common_kwargs["url"],
+            username=common_kwargs["username"],
+            password=common_kwargs["password"],
             download_url=download_url,
-            category=(client_cfg or {}).get("category"),
-            download_path=(client_cfg or {}).get("download_path"),
+            category=common_kwargs["category"],
+            download_path=common_kwargs["download_path"],
             timeout_seconds=timeout_seconds,
-            expected_name=kwargs.get("expected_name"),
-            update_only=bool(kwargs.get("update_only")),
-            exclude_russian=bool(kwargs.get("exclude_russian")),
-            expected_update_number=kwargs.get("expected_update_number"),
-            expected_version=kwargs.get("expected_version"),
+            **queue_options,
         )
-    if protocol == "usenet" or client_type in USENET_CLIENT_TYPES:
+    if _is_usenet_client(protocol, client_type):
         return add_nzb(
-            url=(client_cfg or {}).get("url"),
-            api_key=(client_cfg or {}).get("api_key"),
+            url=common_kwargs["url"],
+            api_key=common_kwargs["api_key"],
             download_url=download_url,
-            category=(client_cfg or {}).get("category"),
+            category=common_kwargs["category"],
             timeout_seconds=timeout_seconds,
-            expected_name=kwargs.get("expected_name"),
-            update_only=bool(kwargs.get("update_only")),
-            exclude_russian=bool(kwargs.get("exclude_russian")),
-            expected_update_number=kwargs.get("expected_update_number"),
-            expected_version=kwargs.get("expected_version"),
+            **queue_options,
         )
     return False, "Unsupported download protocol.", None
 
 
 def list_active_downloads(protocol, client_cfg, timeout_seconds=15):
-    protocol = str(protocol or "").strip().lower()
-    client_type = str((client_cfg or {}).get("type") or "").strip().lower()
-    if protocol == "torrent" or client_type in TORRENT_CLIENT_TYPES:
+    protocol, client_type = _normalize_protocol_and_type(protocol, client_cfg)
+    common_kwargs = _get_common_client_kwargs(client_cfg)
+    if _is_torrent_client(protocol, client_type):
         items = list_active_torrents(
             client_type=client_type,
-            url=(client_cfg or {}).get("url"),
-            username=(client_cfg or {}).get("username"),
-            password=(client_cfg or {}).get("password"),
-            category=(client_cfg or {}).get("category"),
-            download_path=(client_cfg or {}).get("download_path"),
+            url=common_kwargs["url"],
+            username=common_kwargs["username"],
+            password=common_kwargs["password"],
+            category=common_kwargs["category"],
+            download_path=common_kwargs["download_path"],
             timeout_seconds=timeout_seconds,
         )
         for item in items:
             item.setdefault("protocol", "torrent")
             item.setdefault("client_type", client_type)
         return items
-    if protocol == "usenet" or client_type in USENET_CLIENT_TYPES:
+    if _is_usenet_client(protocol, client_type):
         return list_active_usenet(
-            url=(client_cfg or {}).get("url"),
-            api_key=(client_cfg or {}).get("api_key"),
-            category=(client_cfg or {}).get("category"),
+            url=common_kwargs["url"],
+            api_key=common_kwargs["api_key"],
+            category=common_kwargs["category"],
             timeout_seconds=timeout_seconds,
         )
     return []
 
 
 def list_completed_downloads(protocol, client_cfg, timeout_seconds=15):
-    protocol = str(protocol or "").strip().lower()
-    client_type = str((client_cfg or {}).get("type") or "").strip().lower()
-    if protocol == "torrent" or client_type in TORRENT_CLIENT_TYPES:
+    protocol, client_type = _normalize_protocol_and_type(protocol, client_cfg)
+    common_kwargs = _get_common_client_kwargs(client_cfg)
+    if _is_torrent_client(protocol, client_type):
         items = list_completed_torrents(
             client_type=client_type,
-            url=(client_cfg or {}).get("url"),
-            username=(client_cfg or {}).get("username"),
-            password=(client_cfg or {}).get("password"),
-            category=(client_cfg or {}).get("category"),
-            download_path=(client_cfg or {}).get("download_path"),
+            url=common_kwargs["url"],
+            username=common_kwargs["username"],
+            password=common_kwargs["password"],
+            category=common_kwargs["category"],
+            download_path=common_kwargs["download_path"],
             timeout_seconds=timeout_seconds,
         )
         for item in items:
             item.setdefault("protocol", "torrent")
             item.setdefault("client_type", client_type)
         return items
-    if protocol == "usenet" or client_type in USENET_CLIENT_TYPES:
+    if _is_usenet_client(protocol, client_type):
         return list_completed_usenet(
-            url=(client_cfg or {}).get("url"),
-            api_key=(client_cfg or {}).get("api_key"),
-            category=(client_cfg or {}).get("category"),
+            url=common_kwargs["url"],
+            api_key=common_kwargs["api_key"],
+            category=common_kwargs["category"],
             timeout_seconds=timeout_seconds,
         )
     return []
 
 
 def remove_completed_download(protocol, client_cfg, item_id, timeout_seconds=15, delete_files=False):
-    protocol = str(protocol or "").strip().lower()
-    client_type = str((client_cfg or {}).get("type") or "").strip().lower()
-    if protocol == "torrent" or client_type in TORRENT_CLIENT_TYPES:
+    protocol, client_type = _normalize_protocol_and_type(protocol, client_cfg)
+    common_kwargs = _get_common_client_kwargs(client_cfg)
+    if _is_torrent_client(protocol, client_type):
         return remove_torrent(
             client_type=client_type,
-            url=(client_cfg or {}).get("url"),
-            username=(client_cfg or {}).get("username"),
-            password=(client_cfg or {}).get("password"),
+            url=common_kwargs["url"],
+            username=common_kwargs["username"],
+            password=common_kwargs["password"],
             torrent_hash=item_id,
             timeout_seconds=timeout_seconds,
             delete_files=delete_files,
         )
-    if protocol == "usenet" or client_type in USENET_CLIENT_TYPES:
+    if _is_usenet_client(protocol, client_type):
         return remove_history(
-            url=(client_cfg or {}).get("url"),
-            api_key=(client_cfg or {}).get("api_key"),
+            url=common_kwargs["url"],
+            api_key=common_kwargs["api_key"],
             item_id=item_id,
             timeout_seconds=timeout_seconds,
             delete_files=delete_files,
@@ -152,22 +187,22 @@ def remove_completed_download(protocol, client_cfg, item_id, timeout_seconds=15,
 
 
 def remove_active_download(protocol, client_cfg, item_id, timeout_seconds=15, delete_files=False):
-    protocol = str(protocol or "").strip().lower()
-    client_type = str((client_cfg or {}).get("type") or "").strip().lower()
-    if protocol == "torrent" or client_type in TORRENT_CLIENT_TYPES:
+    protocol, client_type = _normalize_protocol_and_type(protocol, client_cfg)
+    common_kwargs = _get_common_client_kwargs(client_cfg)
+    if _is_torrent_client(protocol, client_type):
         return remove_torrent(
             client_type=client_type,
-            url=(client_cfg or {}).get("url"),
-            username=(client_cfg or {}).get("username"),
-            password=(client_cfg or {}).get("password"),
+            url=common_kwargs["url"],
+            username=common_kwargs["username"],
+            password=common_kwargs["password"],
             torrent_hash=item_id,
             timeout_seconds=timeout_seconds,
             delete_files=delete_files,
         )
-    if protocol == "usenet" or client_type in USENET_CLIENT_TYPES:
+    if _is_usenet_client(protocol, client_type):
         return remove_queue_item(
-            url=(client_cfg or {}).get("url"),
-            api_key=(client_cfg or {}).get("api_key"),
+            url=common_kwargs["url"],
+            api_key=common_kwargs["api_key"],
             item_id=item_id,
             timeout_seconds=timeout_seconds,
             delete_files=delete_files,

--- a/app/downloads/client.py
+++ b/app/downloads/client.py
@@ -13,6 +13,10 @@ from app.downloads.usenet_client import (
     remove_queue_item,
     test_sabnzbd,
 )
+from app.downloads.constants import (
+    UNSUPPORTED_CLIENT_TYPE_MESSAGE,
+    UNSUPPORTED_DOWNLOAD_PROTOCOL_MESSAGE,
+)
 
 
 TORRENT_CLIENT_TYPES = {"qbittorrent", "transmission", "deluge"}
@@ -77,7 +81,7 @@ def test_download_client(client_type, url, username=None, password=None, api_key
             api_key=api_key,
             timeout_seconds=timeout_seconds,
         )
-    return False, "Unsupported client type."
+    return False, UNSUPPORTED_CLIENT_TYPE_MESSAGE
 
 
 def queue_download(protocol, client_cfg, download_url, timeout_seconds=15, **kwargs):
@@ -105,7 +109,7 @@ def queue_download(protocol, client_cfg, download_url, timeout_seconds=15, **kwa
             timeout_seconds=timeout_seconds,
             **queue_options,
         )
-    return False, "Unsupported download protocol.", None
+    return False, UNSUPPORTED_DOWNLOAD_PROTOCOL_MESSAGE, None
 
 
 def list_active_downloads(protocol, client_cfg, timeout_seconds=15):
@@ -183,7 +187,7 @@ def remove_completed_download(protocol, client_cfg, item_id, timeout_seconds=15,
             timeout_seconds=timeout_seconds,
             delete_files=delete_files,
         )
-    return False, "Unsupported download protocol."
+    return False, UNSUPPORTED_DOWNLOAD_PROTOCOL_MESSAGE
 
 
 def remove_active_download(protocol, client_cfg, item_id, timeout_seconds=15, delete_files=False):
@@ -207,4 +211,4 @@ def remove_active_download(protocol, client_cfg, item_id, timeout_seconds=15, de
             timeout_seconds=timeout_seconds,
             delete_files=delete_files,
         )
-    return False, "Unsupported download protocol."
+    return False, UNSUPPORTED_DOWNLOAD_PROTOCOL_MESSAGE

--- a/app/downloads/constants.py
+++ b/app/downloads/constants.py
@@ -1,0 +1,3 @@
+DOWNLOADS_USER_AGENT = "AeroFoil/Downloads"
+UNSUPPORTED_CLIENT_TYPE_MESSAGE = "Unsupported client type."
+UNSUPPORTED_DOWNLOAD_PROTOCOL_MESSAGE = "Unsupported download protocol."

--- a/app/downloads/manager.py
+++ b/app/downloads/manager.py
@@ -19,6 +19,7 @@ from app.downloads.client import (
     remove_completed_download,
 )
 from app.downloads.prowlarr import ProwlarrClient, filter_results, pick_best_result
+from app.downloads.versioning import extract_internal_update_version
 from app.library import _ensure_unique_path, _sanitize_component, enqueue_cleanup_roots, enqueue_organize_paths
 from app.settings import load_settings
 from app.utils import get_supported_content_extension, is_supported_content_path, is_wrapped_content_path
@@ -1536,17 +1537,7 @@ def _check_completed(downloads, scan_cb=None, post_cb=None):
 
 
 def _extract_update_version_from_name(name):
-    if not name:
-        return None
-    match = re.search(r"\[v(\d+)\]", name, re.IGNORECASE)
-    if not match:
-        match = re.search(r"(?<![a-z0-9])v(\d+)(?!\.\d)", name, re.IGNORECASE)
-    if not match:
-        return None
-    try:
-        return int(match.group(1))
-    except (TypeError, ValueError):
-        return None
+    return extract_internal_update_version(name)
 
 
 def _select_update_file_path(src_path, expected_version):

--- a/app/downloads/prowlarr.py
+++ b/app/downloads/prowlarr.py
@@ -5,6 +5,8 @@ from urllib.parse import urljoin
 
 import requests
 
+from app.downloads.versioning import extract_internal_update_version
+
 logger = logging.getLogger("downloads.prowlarr")
 
 
@@ -192,16 +194,7 @@ def _has_version(text, version):
 
 
 def _extract_internal_version_token(text):
-    raw = str(text or "")
-    match = re.search(r"\[v(\d+)\]", raw, re.IGNORECASE)
-    if not match:
-        match = re.search(r"(?<![a-z0-9])v(\d+)(?!\.\d)", raw, re.IGNORECASE)
-    if not match:
-        return None
-    try:
-        return int(match.group(1))
-    except Exception:
-        return None
+    return extract_internal_update_version(text)
 
 
 def filter_results(results, min_seeders=0, min_age_minutes=0, required_terms=None, blacklist_terms=None):

--- a/app/downloads/torrent_client.py
+++ b/app/downloads/torrent_client.py
@@ -80,6 +80,24 @@ def _new_client_session(username=None, password=None):
     return session
 
 
+def _transmission_request(session, base, payload, timeout_seconds):
+    resp = session.post(
+        f"{base}/transmission/rpc",
+        json=payload,
+        timeout=timeout_seconds,
+    )
+    if resp.status_code == 409:
+        session_id = resp.headers.get("X-Transmission-Session-Id")
+        if session_id:
+            session.headers.update({"X-Transmission-Session-Id": session_id})
+            resp = session.post(
+                f"{base}/transmission/rpc",
+                json=payload,
+                timeout=timeout_seconds,
+            )
+    return resp
+
+
 def test_torrent_client(client_type, url, username=None, password=None, timeout_seconds=10):
     if not url:
         return False, "Client URL is required."
@@ -163,20 +181,7 @@ def _test_transmission(url, username=None, password=None, timeout_seconds=10):
     session = _new_client_session(username, password)
 
     payload = {"method": "session-get"}
-    resp = session.post(
-        f"{base}/transmission/rpc",
-        json=payload,
-        timeout=timeout_seconds,
-    )
-    if resp.status_code == 409:
-        session_id = resp.headers.get("X-Transmission-Session-Id")
-        if session_id:
-            session.headers.update({"X-Transmission-Session-Id": session_id})
-            resp = session.post(
-                f"{base}/transmission/rpc",
-                json=payload,
-                timeout=timeout_seconds,
-            )
+    resp = _transmission_request(session, base, payload, timeout_seconds)
     if resp.status_code != 200:
         return False, f"Transmission returned {resp.status_code}."
     return True, "Transmission OK."
@@ -425,13 +430,7 @@ def _add_transmission(url, username, password, download_url, category, download_
         payload["arguments"]["download-dir"] = download_path
 
     def _request(payload_body):
-        resp = session.post(f"{base}/transmission/rpc", json=payload_body, timeout=timeout_seconds)
-        if resp.status_code == 409:
-            session_id = resp.headers.get("X-Transmission-Session-Id")
-            if session_id:
-                session.headers.update({"X-Transmission-Session-Id": session_id})
-                resp = session.post(f"{base}/transmission/rpc", json=payload_body, timeout=timeout_seconds)
-        return resp
+        return _transmission_request(session, base, payload_body, timeout_seconds)
 
     resp = _request(payload)
     if resp.status_code != 200:
@@ -587,12 +586,7 @@ def _list_active_transmission(url, username, password, category, download_path, 
             ]
         },
     }
-    resp = session.post(f"{base}/transmission/rpc", json=payload, timeout=timeout_seconds)
-    if resp.status_code == 409:
-        session_id = resp.headers.get("X-Transmission-Session-Id")
-        if session_id:
-            session.headers.update({"X-Transmission-Session-Id": session_id})
-            resp = session.post(f"{base}/transmission/rpc", json=payload, timeout=timeout_seconds)
+    resp = _transmission_request(session, base, payload, timeout_seconds)
     if resp.status_code != 200:
         return []
     torrents = resp.json().get("arguments", {}).get("torrents", []) or []
@@ -749,12 +743,7 @@ def _list_completed_transmission(url, username, password, category, download_pat
         "method": "torrent-get",
         "arguments": {"fields": ["id", "hashString", "percentDone", "labels", "downloadDir", "name"]},
     }
-    resp = session.post(f"{base}/transmission/rpc", json=payload, timeout=timeout_seconds)
-    if resp.status_code == 409:
-        session_id = resp.headers.get("X-Transmission-Session-Id")
-        if session_id:
-            session.headers.update({"X-Transmission-Session-Id": session_id})
-            resp = session.post(f"{base}/transmission/rpc", json=payload, timeout=timeout_seconds)
+    resp = _transmission_request(session, base, payload, timeout_seconds)
     if resp.status_code != 200:
         return []
     torrents = resp.json().get("arguments", {}).get("torrents", []) or []
@@ -882,12 +871,7 @@ def _remove_transmission(url, username, password, torrent_hash, timeout_seconds,
         "method": "torrent-remove",
         "arguments": {"ids": [torrent_hash], "delete-local-data": bool(delete_files)},
     }
-    resp = session.post(f"{base}/transmission/rpc", json=payload, timeout=timeout_seconds)
-    if resp.status_code == 409:
-        session_id = resp.headers.get("X-Transmission-Session-Id")
-        if session_id:
-            session.headers.update({"X-Transmission-Session-Id": session_id})
-            resp = session.post(f"{base}/transmission/rpc", json=payload, timeout=timeout_seconds)
+    resp = _transmission_request(session, base, payload, timeout_seconds)
     if resp.status_code != 200:
         return False, f"Transmission returned {resp.status_code}."
     return True, "Transmission removed torrent."

--- a/app/downloads/torrent_client.py
+++ b/app/downloads/torrent_client.py
@@ -8,6 +8,7 @@ from urllib.parse import urlencode
 
 import requests
 
+from app.downloads.constants import DOWNLOADS_USER_AGENT, UNSUPPORTED_CLIENT_TYPE_MESSAGE
 from app.downloads.update_selection import (
     TORRENT_UPDATE_SELECTION_ERROR,
     get_matching_update_indices,
@@ -23,7 +24,6 @@ logger = logging.getLogger("downloads.qbittorrent")
 AEROFOIL_MANAGED_TAG = "aerofoil"
 LEGACY_OWNFOIL_MANAGED_TAG = "ownfoil"
 MANAGED_TAGS = (AEROFOIL_MANAGED_TAG, LEGACY_OWNFOIL_MANAGED_TAG)
-DOWNLOADS_USER_AGENT = "AeroFoil/Downloads"
 
 
 def _normalize_labels(values):
@@ -82,7 +82,7 @@ def test_torrent_client(client_type, url, username=None, password=None, timeout_
         return _test_transmission(url, username, password, timeout_seconds)
     if client_type == "deluge":
         return _test_deluge(url, password, timeout_seconds)
-    return False, "Unsupported client type."
+    return False, UNSUPPORTED_CLIENT_TYPE_MESSAGE
 
 
 def add_torrent(client_type, url, username=None, password=None, download_url=None, category=None, download_path=None, timeout_seconds=15, expected_name=None, update_only=False, exclude_russian=False, expected_update_number=None, expected_version=None):
@@ -95,7 +95,7 @@ def add_torrent(client_type, url, username=None, password=None, download_url=Non
         return _add_transmission(url, username, password, download_url, category, download_path, timeout_seconds, expected_name, update_only, exclude_russian, expected_update_number, expected_version)
     if client_type == "deluge":
         return _add_deluge(url, password, download_url, category, download_path, timeout_seconds, update_only, exclude_russian, expected_update_number, expected_version)
-    return False, "Unsupported client type.", None
+    return False, UNSUPPORTED_CLIENT_TYPE_MESSAGE, None
 
 
 def list_completed(client_type, url, username=None, password=None, category=None, download_path=None, timeout_seconds=15):
@@ -130,13 +130,13 @@ def remove_torrent(client_type, url, torrent_hash, username=None, password=None,
         return _remove_transmission(url, username, password, torrent_hash, timeout_seconds, delete_files=delete_files)
     if client_type == "deluge":
         return _remove_deluge(url, password, torrent_hash, timeout_seconds, delete_files=delete_files)
-    return False, "Unsupported client type."
+    return False, UNSUPPORTED_CLIENT_TYPE_MESSAGE
 
 
 def _test_qbittorrent(url, username=None, password=None, timeout_seconds=10):
     base = url.rstrip("/")
     session = requests.Session()
-    session.headers.update({"User-Agent": "AeroFoil/Downloads"})
+    session.headers.update({"User-Agent": DOWNLOADS_USER_AGENT})
     if username or password:
         login_resp = session.post(
             f"{base}/api/v2/auth/login",
@@ -154,7 +154,7 @@ def _test_qbittorrent(url, username=None, password=None, timeout_seconds=10):
 def _test_transmission(url, username=None, password=None, timeout_seconds=10):
     base = url.rstrip("/")
     session = requests.Session()
-    session.headers.update({"User-Agent": "AeroFoil/Downloads"})
+    session.headers.update({"User-Agent": DOWNLOADS_USER_AGENT})
     if username or password:
         session.auth = (username or "", password or "")
 
@@ -181,7 +181,7 @@ def _test_transmission(url, username=None, password=None, timeout_seconds=10):
 def _deluge_json_rpc(url, password, method, params=None, timeout_seconds=10):
     base = url.rstrip("/")
     session = requests.Session()
-    session.headers.update({"User-Agent": "AeroFoil/Downloads"})
+    session.headers.update({"User-Agent": DOWNLOADS_USER_AGENT})
     if password is None:
         password = ""
     payload = {
@@ -292,7 +292,7 @@ def _add_deluge(url, password, download_url, category, download_path, timeout_se
 def _add_qbittorrent(url, username, password, download_url, category, download_path, timeout_seconds, expected_name, update_only, exclude_russian, expected_update_number, expected_version):
     base = url.rstrip("/")
     session = requests.Session()
-    session.headers.update({"User-Agent": "AeroFoil/Downloads"})
+    session.headers.update({"User-Agent": DOWNLOADS_USER_AGENT})
     if username or password:
         login_resp = session.post(
             f"{base}/api/v2/auth/login",
@@ -400,7 +400,7 @@ def _add_qbittorrent(url, username, password, download_url, category, download_p
 def _add_transmission(url, username, password, download_url, category, download_path, timeout_seconds, expected_name, update_only, exclude_russian, expected_update_number, expected_version):
     base = url.rstrip("/")
     session = requests.Session()
-    session.headers.update({"User-Agent": "AeroFoil/Downloads"})
+    session.headers.update({"User-Agent": DOWNLOADS_USER_AGENT})
     if username or password:
         session.auth = (username or "", password or "")
 
@@ -513,7 +513,7 @@ def _qb_is_active(item):
 def _list_active_qbittorrent(url, username, password, category, download_path, timeout_seconds):
     base = url.rstrip("/")
     session = requests.Session()
-    session.headers.update({"User-Agent": "AeroFoil/Downloads"})
+    session.headers.update({"User-Agent": DOWNLOADS_USER_AGENT})
     if username or password:
         login_resp = session.post(
             f"{base}/api/v2/auth/login",
@@ -578,7 +578,7 @@ _TRANSMISSION_STATUS = {
 def _list_active_transmission(url, username, password, category, download_path, timeout_seconds):
     base = url.rstrip("/")
     session = requests.Session()
-    session.headers.update({"User-Agent": "AeroFoil/Downloads"})
+    session.headers.update({"User-Agent": DOWNLOADS_USER_AGENT})
     if username or password:
         session.auth = (username or "", password or "")
 
@@ -691,7 +691,7 @@ def _list_active_deluge(url, password, category, download_path, timeout_seconds)
 def _list_completed_qbittorrent(url, username, password, category, download_path, timeout_seconds):
     base = url.rstrip("/")
     session = requests.Session()
-    session.headers.update({"User-Agent": "AeroFoil/Downloads"})
+    session.headers.update({"User-Agent": DOWNLOADS_USER_AGENT})
     if username or password:
         login_resp = session.post(
             f"{base}/api/v2/auth/login",
@@ -750,7 +750,7 @@ def _list_completed_qbittorrent(url, username, password, category, download_path
 def _list_completed_transmission(url, username, password, category, download_path, timeout_seconds):
     base = url.rstrip("/")
     session = requests.Session()
-    session.headers.update({"User-Agent": "AeroFoil/Downloads"})
+    session.headers.update({"User-Agent": DOWNLOADS_USER_AGENT})
     if username or password:
         session.auth = (username or "", password or "")
 
@@ -854,7 +854,7 @@ def _is_deluge_managed_label(label):
 def _remove_qbittorrent(url, username, password, torrent_hash, timeout_seconds, delete_files=False):
     base = url.rstrip("/")
     session = requests.Session()
-    session.headers.update({"User-Agent": "AeroFoil/Downloads"})
+    session.headers.update({"User-Agent": DOWNLOADS_USER_AGENT})
     if username or password:
         login_resp = session.post(
             f"{base}/api/v2/auth/login",
@@ -887,7 +887,7 @@ def _remove_qbittorrent_with_session(session, base, torrent_hash, timeout_second
 def _remove_transmission(url, username, password, torrent_hash, timeout_seconds, delete_files=False):
     base = url.rstrip("/")
     session = requests.Session()
-    session.headers.update({"User-Agent": "AeroFoil/Downloads"})
+    session.headers.update({"User-Agent": DOWNLOADS_USER_AGENT})
     if username or password:
         session.auth = (username or "", password or "")
 

--- a/app/downloads/torrent_client.py
+++ b/app/downloads/torrent_client.py
@@ -98,6 +98,17 @@ def _transmission_request(session, base, payload, timeout_seconds):
     return resp
 
 
+def _login_qbittorrent(session, base, username=None, password=None, timeout_seconds=10):
+    if not username and not password:
+        return True
+    login_resp = session.post(
+        f"{base}/api/v2/auth/login",
+        data={"username": username or "", "password": password or ""},
+        timeout=timeout_seconds,
+    )
+    return login_resp.status_code == 200 and login_resp.text.strip() in ("Ok.", "")
+
+
 def test_torrent_client(client_type, url, username=None, password=None, timeout_seconds=10):
     if not url:
         return False, "Client URL is required."
@@ -162,14 +173,8 @@ def remove_torrent(client_type, url, torrent_hash, username=None, password=None,
 def _test_qbittorrent(url, username=None, password=None, timeout_seconds=10):
     base = url.rstrip("/")
     session = _new_client_session()
-    if username or password:
-        login_resp = session.post(
-            f"{base}/api/v2/auth/login",
-            data={"username": username or "", "password": password or ""},
-            timeout=timeout_seconds,
-        )
-        if login_resp.status_code != 200 or login_resp.text.strip() not in ("Ok.", ""):
-            return False, "qBittorrent login failed."
+    if not _login_qbittorrent(session, base, username, password, timeout_seconds):
+        return False, "qBittorrent login failed."
     version_resp = session.get(f"{base}/api/v2/app/version", timeout=timeout_seconds)
     if version_resp.status_code != 200:
         return False, f"qBittorrent returned {version_resp.status_code}."
@@ -300,14 +305,8 @@ def _add_deluge(url, password, download_url, category, download_path, timeout_se
 def _add_qbittorrent(url, username, password, download_url, category, download_path, timeout_seconds, expected_name, update_only, exclude_russian, expected_update_number, expected_version):
     base = url.rstrip("/")
     session = _new_client_session()
-    if username or password:
-        login_resp = session.post(
-            f"{base}/api/v2/auth/login",
-            data={"username": username or "", "password": password or ""},
-            timeout=timeout_seconds,
-        )
-        if login_resp.status_code != 200 or login_resp.text.strip() not in ("Ok.", ""):
-            return False, "qBittorrent login failed.", None
+    if not _login_qbittorrent(session, base, username, password, timeout_seconds):
+        return False, "qBittorrent login failed.", None
 
     data = {"urls": download_url}
     temp_tag = None
@@ -511,14 +510,8 @@ def _qb_is_active(item):
 def _list_active_qbittorrent(url, username, password, category, download_path, timeout_seconds):
     base = url.rstrip("/")
     session = _new_client_session()
-    if username or password:
-        login_resp = session.post(
-            f"{base}/api/v2/auth/login",
-            data={"username": username or "", "password": password or ""},
-            timeout=timeout_seconds,
-        )
-        if login_resp.status_code != 200 or login_resp.text.strip() not in ("Ok.", ""):
-            return []
+    if not _login_qbittorrent(session, base, username, password, timeout_seconds):
+        return []
 
     items = _fetch_qbittorrent_managed_items(
         session,
@@ -680,14 +673,8 @@ def _list_active_deluge(url, password, category, download_path, timeout_seconds)
 def _list_completed_qbittorrent(url, username, password, category, download_path, timeout_seconds):
     base = url.rstrip("/")
     session = _new_client_session()
-    if username or password:
-        login_resp = session.post(
-            f"{base}/api/v2/auth/login",
-            data={"username": username or "", "password": password or ""},
-            timeout=timeout_seconds,
-        )
-        if login_resp.status_code != 200 or login_resp.text.strip() not in ("Ok.", ""):
-            return []
+    if not _login_qbittorrent(session, base, username, password, timeout_seconds):
+        return []
 
     def fetch_with_params(extra_params=None):
         params = extra_params or {}
@@ -834,14 +821,8 @@ def _is_deluge_managed_label(label):
 def _remove_qbittorrent(url, username, password, torrent_hash, timeout_seconds, delete_files=False):
     base = url.rstrip("/")
     session = _new_client_session()
-    if username or password:
-        login_resp = session.post(
-            f"{base}/api/v2/auth/login",
-            data={"username": username or "", "password": password or ""},
-            timeout=timeout_seconds,
-        )
-        if login_resp.status_code != 200 or login_resp.text.strip() not in ("Ok.", ""):
-            return False, "qBittorrent login failed."
+    if not _login_qbittorrent(session, base, username, password, timeout_seconds):
+        return False, "qBittorrent login failed."
     resp = session.post(
         f"{base}/api/v2/torrents/delete",
         data={"hashes": torrent_hash, "deleteFiles": "true" if delete_files else "false"},

--- a/app/downloads/torrent_client.py
+++ b/app/downloads/torrent_client.py
@@ -8,6 +8,17 @@ from urllib.parse import urlencode
 
 import requests
 
+from app.downloads.update_selection import (
+    TORRENT_UPDATE_SELECTION_ERROR,
+    get_matching_update_indices,
+    poll_update_file_names,
+    preflight_has_matching_update,
+)
+from app.downloads.versioning import (
+    select_update_entry_ids,
+    select_update_file_indices as shared_select_update_file_indices,
+)
+
 logger = logging.getLogger("downloads.qbittorrent")
 AEROFOIL_MANAGED_TAG = "aerofoil"
 LEGACY_OWNFOIL_MANAGED_TAG = "ownfoil"
@@ -244,29 +255,19 @@ def _add_deluge(url, password, download_url, category, download_path, timeout_se
         torrent_hash = _extract_magnet_hash(download_url)
 
     if update_only and torrent_hash:
-        file_names = None
-        for _ in range(10):
-            ok, status = _deluge_json_rpc(
-                url,
-                password,
-                "core.get_torrent_status",
-                [torrent_hash, ["files"]],
-                timeout_seconds=timeout_seconds
-            )
-            if ok and isinstance(status, dict) and status.get("files"):
-                files = status.get("files") or []
-                file_names = [f.get("path") for f in files]
-                break
-            time.sleep(1)
-        keep_indices = _select_update_file_indices(
-            file_names or [],
+        file_names = poll_update_file_names(
+            lambda: _fetch_deluge_file_names(url, password, torrent_hash, timeout_seconds),
+            sleep_fn=time.sleep,
+        )
+        keep_indices = get_matching_update_indices(
+            file_names,
             expected_update_number=expected_update_number,
             expected_version=expected_version,
-            exclude_russian=exclude_russian
+            exclude_russian=exclude_russian,
         )
         if not keep_indices:
             _remove_deluge(url, password, torrent_hash, timeout_seconds)
-            return False, "No matching update version found in torrent.", None
+            return False, TORRENT_UPDATE_SELECTION_ERROR, None
         priorities = [0] * len(file_names or [])
         for idx in keep_indices:
             if idx < len(priorities):
@@ -305,15 +306,13 @@ def _add_qbittorrent(url, username, password, download_url, category, download_p
     temp_tag = None
     if update_only:
         preflight_files = _get_torrent_file_list(download_url, timeout_seconds)
-        if preflight_files is not None:
-            keep_ids = _select_update_file_indices(
-                preflight_files,
-                expected_update_number=expected_update_number,
-                expected_version=expected_version,
-                exclude_russian=exclude_russian
-            )
-            if not keep_ids:
-                return False, "No matching update version found in torrent.", None
+        if not preflight_has_matching_update(
+            preflight_files,
+            expected_update_number=expected_update_number,
+            expected_version=expected_version,
+            exclude_russian=exclude_russian,
+        ):
+            return False, TORRENT_UPDATE_SELECTION_ERROR, None
         temp_tag = f"aerofoil_update_{int(time.time())}_{secrets.token_hex(3)}"
     if category:
         data["category"] = category
@@ -385,7 +384,7 @@ def _add_qbittorrent(url, username, password, download_url, category, download_p
             if temp_tag:
                 _remove_qbittorrent_tag(session, base, torrent_hash, temp_tag, timeout_seconds)
             _remove_qbittorrent_with_session(session, base, torrent_hash, timeout_seconds)
-            return False, "No matching update version found in torrent.", None
+            return False, TORRENT_UPDATE_SELECTION_ERROR, None
         _resume_qbittorrent(session, base, torrent_hash, timeout_seconds)
         if temp_tag:
             _remove_qbittorrent_tag(session, base, torrent_hash, temp_tag, timeout_seconds)
@@ -408,15 +407,13 @@ def _add_transmission(url, username, password, download_url, category, download_
     preflight_files = None
     if update_only:
         preflight_files = _get_torrent_file_list(download_url, timeout_seconds)
-        if preflight_files is not None:
-            keep_ids = _select_update_file_indices(
-                preflight_files,
-                expected_update_number=expected_update_number,
-                expected_version=expected_version,
-                exclude_russian=exclude_russian
-            )
-            if not keep_ids:
-                return False, "No matching update version found in torrent.", None
+        if not preflight_has_matching_update(
+            preflight_files,
+            expected_update_number=expected_update_number,
+            expected_version=expected_version,
+            exclude_russian=exclude_russian,
+        ):
+            return False, TORRENT_UPDATE_SELECTION_ERROR, None
 
     payload = {"method": "torrent-add", "arguments": {"filename": download_url}}
     if update_only:
@@ -448,31 +445,20 @@ def _add_transmission(url, username, password, download_url, category, download_
     if update_only and not torrent_id:
         return False, "Unable to resolve torrent id for file selection.", None
     if update_only and torrent_id:
-        file_indices = None
-        file_names = None
-        for _ in range(10):
-            info_payload = {
-                "method": "torrent-get",
-                "arguments": {"fields": ["id", "files", "name"], "ids": [torrent_id]}
-            }
-            info_resp = _request(info_payload)
-            if info_resp.status_code == 200:
-                torrents = info_resp.json().get("arguments", {}).get("torrents", []) or []
-                if torrents and torrents[0].get("files"):
-                    files = torrents[0].get("files") or []
-                    file_names = [f.get("name") for f in files]
-                    file_indices = _select_update_file_indices(
-                        file_names,
-                        expected_update_number=expected_update_number,
-                        expected_version=expected_version,
-                        exclude_russian=exclude_russian
-                    )
-                    break
-            time.sleep(1)
+        file_names = poll_update_file_names(
+            lambda: _fetch_transmission_file_names(_request, torrent_id),
+            sleep_fn=time.sleep,
+        )
+        file_indices = get_matching_update_indices(
+            file_names,
+            expected_update_number=expected_update_number,
+            expected_version=expected_version,
+            exclude_russian=exclude_russian,
+        )
         if not file_indices:
             if torrent_hash:
                 _remove_transmission(url, username, password, torrent_hash, timeout_seconds)
-            return False, "No matching update version found in torrent.", None
+            return False, TORRENT_UPDATE_SELECTION_ERROR, None
         all_indices = list(range(len(file_names))) if file_names else []
         unwanted = [i for i in all_indices if i not in file_indices]
         set_payload = {
@@ -1053,114 +1039,9 @@ def _get_torrent_file_list(download_url, timeout_seconds):
     return None
 
 
-def _extract_internal_update_version(name):
-    if not name:
-        return None
-    match = re.search(r"\[v(\d+)\]", name, re.IGNORECASE)
-    if not match:
-        match = re.search(r"(?<![a-z0-9])v(\d+)(?!\.\d)", name, re.IGNORECASE)
-    if not match:
-        return None
-    try:
-        return int(match.group(1))
-    except (TypeError, ValueError):
-        return None
-
-
-def _expected_semantic_version(expected_version):
-    try:
-        value = int(expected_version)
-    except (TypeError, ValueError):
-        return None
-    if value < 0:
-        return None
-    return (
-        (value >> 16) & 0xFFFF,
-        (value >> 8) & 0xFF,
-        value & 0xFF,
-    )
-
-
-def _normalize_semantic_version_parts(parts):
-    values = [int(part) for part in (parts or [])]
-    while len(values) > 3 and values[-1] == 0:
-        values.pop()
-    if len(values) > 3:
-        return None
-    while len(values) < 3:
-        values.append(0)
-    return tuple(values)
-
-
-def _extract_semantic_versions(name):
-    out = []
-    for match in re.finditer(r"(?<![a-z0-9])(\d+(?:\.\d+){1,3})(?![a-z0-9])", str(name or ""), re.IGNORECASE):
-        try:
-            normalized = _normalize_semantic_version_parts(match.group(1).split("."))
-        except (TypeError, ValueError):
-            normalized = None
-        if normalized:
-            out.append(normalized)
-    return out
-
-
-def _collect_update_file_versions(file_entries, exclude_russian=False):
-    internal_versions = []
-    semantic_versions = []
-    for entry_id, raw_name in file_entries or []:
-        name = str(raw_name or "")
-        lowered = name.lower()
-        if exclude_russian and ("russian" in lowered or "rus" in lowered):
-            continue
-        internal_version = _extract_internal_update_version(name)
-        if internal_version is not None:
-            internal_versions.append((internal_version, entry_id))
-        for semantic_version in _extract_semantic_versions(name):
-            semantic_versions.append((semantic_version, entry_id))
-    return internal_versions, semantic_versions
-
-
-def _select_update_entry_ids(file_entries, expected_update_number=None, expected_version=None, exclude_russian=False):
-    internal_versions, semantic_versions = _collect_update_file_versions(
-        file_entries,
-        exclude_russian=exclude_russian,
-    )
-    expected_value = None
-    if expected_version is not None:
-        try:
-            expected_value = int(expected_version)
-        except (TypeError, ValueError):
-            expected_value = None
-    if expected_value and expected_value > 0:
-        exact_internal = [entry_id for version, entry_id in internal_versions if version == expected_value]
-        if exact_internal:
-            return exact_internal
-        expected_semantic = _expected_semantic_version(expected_value)
-        if expected_semantic:
-            exact_semantic = [entry_id for version, entry_id in semantic_versions if version == expected_semantic]
-            if exact_semantic:
-                return exact_semantic
-    if expected_update_number is not None and expected_update_number > 0:
-        exact_update_number = [
-            entry_id for version, entry_id in internal_versions
-            if (version // 65536) == expected_update_number
-        ]
-        if exact_update_number:
-            return exact_update_number
-    if internal_versions:
-        highest_internal = max(version for version, _entry_id in internal_versions)
-        return [entry_id for version, entry_id in internal_versions if version == highest_internal]
-    if semantic_versions:
-        highest_semantic = max(version for version, _entry_id in semantic_versions)
-        return [entry_id for version, entry_id in semantic_versions if version == highest_semantic]
-    return []
-
-
 def _select_update_file_indices(file_names, expected_update_number=None, expected_version=None, exclude_russian=False):
-    if not file_names:
-        return []
-    return _select_update_entry_ids(
-        list(enumerate(file_names)),
+    return shared_select_update_file_indices(
+        file_names,
         expected_update_number=expected_update_number,
         expected_version=expected_version,
         exclude_russian=exclude_russian,
@@ -1406,7 +1287,7 @@ def _select_qbittorrent_highest_version(session, base, torrent_hash, timeout_sec
         all_ids.append(str(file_id))
         file_entries.append((file_id, name))
     keep_ids = [
-        str(file_id) for file_id in _select_update_entry_ids(
+        str(file_id) for file_id in select_update_entry_ids(
             file_entries,
             expected_update_number=expected_update_number,
             expected_version=expected_version,
@@ -1459,6 +1340,35 @@ def _select_qbittorrent_highest_version(session, base, torrent_hash, timeout_sec
     if retry_enable:
         _set_qbittorrent_file_priority(session, base, torrent_hash, retry_enable, 1, timeout_seconds, per_file=True)
     return True
+
+
+def _fetch_deluge_file_names(url, password, torrent_hash, timeout_seconds):
+    ok, status = _deluge_json_rpc(
+        url,
+        password,
+        "core.get_torrent_status",
+        [torrent_hash, ["files"]],
+        timeout_seconds=timeout_seconds,
+    )
+    if not ok or not isinstance(status, dict) or not status.get("files"):
+        return []
+    files = status.get("files") or []
+    return [f.get("path") for f in files]
+
+
+def _fetch_transmission_file_names(request_fn, torrent_id):
+    info_payload = {
+        "method": "torrent-get",
+        "arguments": {"fields": ["id", "files", "name"], "ids": [torrent_id]},
+    }
+    info_resp = request_fn(info_payload)
+    if info_resp.status_code != 200:
+        return []
+    torrents = info_resp.json().get("arguments", {}).get("torrents", []) or []
+    if not torrents or not torrents[0].get("files"):
+        return []
+    files = torrents[0].get("files") or []
+    return [f.get("name") for f in files]
 
 
 def _set_qbittorrent_file_priority(session, base, torrent_hash, ids, priority, timeout_seconds, per_file=False):

--- a/app/downloads/torrent_client.py
+++ b/app/downloads/torrent_client.py
@@ -1053,23 +1053,78 @@ def _get_torrent_file_list(download_url, timeout_seconds):
     return None
 
 
-def _select_update_file_indices(file_names, expected_update_number=None, expected_version=None, exclude_russian=False):
-    if not file_names:
-        return []
-    version_map = []
-    for idx, name in enumerate(file_names):
-        name = name or ""
+def _extract_internal_update_version(name):
+    if not name:
+        return None
+    match = re.search(r"\[v(\d+)\]", name, re.IGNORECASE)
+    if not match:
+        match = re.search(r"(?<![a-z0-9])v(\d+)(?!\.\d)", name, re.IGNORECASE)
+    if not match:
+        return None
+    try:
+        return int(match.group(1))
+    except (TypeError, ValueError):
+        return None
+
+
+def _expected_semantic_version(expected_version):
+    try:
+        value = int(expected_version)
+    except (TypeError, ValueError):
+        return None
+    if value < 0:
+        return None
+    return (
+        (value >> 16) & 0xFFFF,
+        (value >> 8) & 0xFF,
+        value & 0xFF,
+    )
+
+
+def _normalize_semantic_version_parts(parts):
+    values = [int(part) for part in (parts or [])]
+    while len(values) > 3 and values[-1] == 0:
+        values.pop()
+    if len(values) > 3:
+        return None
+    while len(values) < 3:
+        values.append(0)
+    return tuple(values)
+
+
+def _extract_semantic_versions(name):
+    out = []
+    for match in re.finditer(r"(?<![a-z0-9])(\d+(?:\.\d+){1,3})(?![a-z0-9])", str(name or ""), re.IGNORECASE):
+        try:
+            normalized = _normalize_semantic_version_parts(match.group(1).split("."))
+        except (TypeError, ValueError):
+            normalized = None
+        if normalized:
+            out.append(normalized)
+    return out
+
+
+def _collect_update_file_versions(file_entries, exclude_russian=False):
+    internal_versions = []
+    semantic_versions = []
+    for entry_id, raw_name in file_entries or []:
+        name = str(raw_name or "")
         lowered = name.lower()
         if exclude_russian and ("russian" in lowered or "rus" in lowered):
             continue
-        match = re.search(r"\[v(\d+)\]", name, re.IGNORECASE)
-        if match:
-            try:
-                version_map.append((int(match.group(1)), idx))
-            except ValueError:
-                continue
-    if not version_map:
-        return []
+        internal_version = _extract_internal_update_version(name)
+        if internal_version is not None:
+            internal_versions.append((internal_version, entry_id))
+        for semantic_version in _extract_semantic_versions(name):
+            semantic_versions.append((semantic_version, entry_id))
+    return internal_versions, semantic_versions
+
+
+def _select_update_entry_ids(file_entries, expected_update_number=None, expected_version=None, exclude_russian=False):
+    internal_versions, semantic_versions = _collect_update_file_versions(
+        file_entries,
+        exclude_russian=exclude_russian,
+    )
     expected_value = None
     if expected_version is not None:
         try:
@@ -1077,11 +1132,39 @@ def _select_update_file_indices(file_names, expected_update_number=None, expecte
         except (TypeError, ValueError):
             expected_value = None
     if expected_value and expected_value > 0:
-        return [idx for version, idx in version_map if version == expected_value]
+        exact_internal = [entry_id for version, entry_id in internal_versions if version == expected_value]
+        if exact_internal:
+            return exact_internal
+        expected_semantic = _expected_semantic_version(expected_value)
+        if expected_semantic:
+            exact_semantic = [entry_id for version, entry_id in semantic_versions if version == expected_semantic]
+            if exact_semantic:
+                return exact_semantic
     if expected_update_number is not None and expected_update_number > 0:
-        return [idx for version, idx in version_map if version == expected_update_number]
-    highest = max(version_map, key=lambda pair: pair[0])[0]
-    return [idx for version, idx in version_map if version == highest]
+        exact_update_number = [
+            entry_id for version, entry_id in internal_versions
+            if (version // 65536) == expected_update_number
+        ]
+        if exact_update_number:
+            return exact_update_number
+    if internal_versions:
+        highest_internal = max(version for version, _entry_id in internal_versions)
+        return [entry_id for version, entry_id in internal_versions if version == highest_internal]
+    if semantic_versions:
+        highest_semantic = max(version for version, _entry_id in semantic_versions)
+        return [entry_id for version, entry_id in semantic_versions if version == highest_semantic]
+    return []
+
+
+def _select_update_file_indices(file_names, expected_update_number=None, expected_version=None, exclude_russian=False):
+    if not file_names:
+        return []
+    return _select_update_entry_ids(
+        list(enumerate(file_names)),
+        expected_update_number=expected_update_number,
+        expected_version=expected_version,
+        exclude_russian=exclude_russian,
+    )
 
 
 def _extract_info_bencode_slice(data):
@@ -1311,56 +1394,32 @@ def _select_qbittorrent_highest_version(session, base, torrent_hash, timeout_sec
         return
     files = resp.json() or []
     logger.info("Torrent %s file list entries: %s", torrent_hash, len(files))
-    version_map = []
     all_ids = []
+    file_entries = []
     for file in files:
         name = file.get("name") or ""
-        lowered = name.lower()
         file_id = file.get("index")
         if file_id is None:
             file_id = file.get("id")
         if file_id is None:
             continue
         all_ids.append(str(file_id))
-        if exclude_russian and ("russian" in lowered or "rus" in lowered):
-            continue
-        match = re.search(r"\[v(\d+)\]", name, re.IGNORECASE)
-        if match:
-            try:
-                version_map.append((int(match.group(1)), file_id))
-            except ValueError:
-                continue
-    if not version_map:
-        logger.warning("No version tags found in torrent %s file list.", torrent_hash)
-        return False
-    expected_version_value = None
-    if expected_version is not None:
-        try:
-            expected_version_value = int(expected_version)
-        except (TypeError, ValueError):
-            expected_version_value = None
-    if expected_version_value and expected_version_value > 0:
-        keep_ids = [str(file_id) for version, file_id in version_map if version == expected_version_value]
-        if not keep_ids:
-            logger.warning(
-                "No update files found for expected version v%s in torrent %s.",
-                expected_version_value,
-                torrent_hash
-            )
-            return False
-    elif expected_update_number is not None and expected_update_number > 0:
-        keep_ids = [str(file_id) for version, file_id in version_map if version == expected_update_number]
-        if not keep_ids:
-            logger.warning(
-                "No update files found for expected update number v%s in torrent %s.",
-                expected_update_number,
-                torrent_hash
-            )
-            return False
-    else:
-        keep_ids = [str(file_id) for version, file_id in version_map if version > 0]
+        file_entries.append((file_id, name))
+    keep_ids = [
+        str(file_id) for file_id in _select_update_entry_ids(
+            file_entries,
+            expected_update_number=expected_update_number,
+            expected_version=expected_version,
+            exclude_russian=exclude_russian,
+        )
+    ]
     if not keep_ids:
-        logger.warning("No update files found (v>0) in torrent %s.", torrent_hash)
+        logger.warning(
+            "No update files found for torrent %s (expected_version=%s, expected_update_number=%s).",
+            torrent_hash,
+            expected_version,
+            expected_update_number,
+        )
         return False
     keep_set = set(keep_ids)
     if all_ids:

--- a/app/downloads/torrent_client.py
+++ b/app/downloads/torrent_client.py
@@ -72,6 +72,14 @@ def _fetch_qbittorrent_managed_items(session, base, timeout_seconds, extra_param
     return items
 
 
+def _new_client_session(username=None, password=None):
+    session = requests.Session()
+    session.headers.update({"User-Agent": DOWNLOADS_USER_AGENT})
+    if username or password:
+        session.auth = (username or "", password or "")
+    return session
+
+
 def test_torrent_client(client_type, url, username=None, password=None, timeout_seconds=10):
     if not url:
         return False, "Client URL is required."
@@ -135,8 +143,7 @@ def remove_torrent(client_type, url, torrent_hash, username=None, password=None,
 
 def _test_qbittorrent(url, username=None, password=None, timeout_seconds=10):
     base = url.rstrip("/")
-    session = requests.Session()
-    session.headers.update({"User-Agent": DOWNLOADS_USER_AGENT})
+    session = _new_client_session()
     if username or password:
         login_resp = session.post(
             f"{base}/api/v2/auth/login",
@@ -153,10 +160,7 @@ def _test_qbittorrent(url, username=None, password=None, timeout_seconds=10):
 
 def _test_transmission(url, username=None, password=None, timeout_seconds=10):
     base = url.rstrip("/")
-    session = requests.Session()
-    session.headers.update({"User-Agent": DOWNLOADS_USER_AGENT})
-    if username or password:
-        session.auth = (username or "", password or "")
+    session = _new_client_session(username, password)
 
     payload = {"method": "session-get"}
     resp = session.post(
@@ -180,8 +184,7 @@ def _test_transmission(url, username=None, password=None, timeout_seconds=10):
 
 def _deluge_json_rpc(url, password, method, params=None, timeout_seconds=10):
     base = url.rstrip("/")
-    session = requests.Session()
-    session.headers.update({"User-Agent": DOWNLOADS_USER_AGENT})
+    session = _new_client_session()
     if password is None:
         password = ""
     payload = {
@@ -291,8 +294,7 @@ def _add_deluge(url, password, download_url, category, download_path, timeout_se
 
 def _add_qbittorrent(url, username, password, download_url, category, download_path, timeout_seconds, expected_name, update_only, exclude_russian, expected_update_number, expected_version):
     base = url.rstrip("/")
-    session = requests.Session()
-    session.headers.update({"User-Agent": DOWNLOADS_USER_AGENT})
+    session = _new_client_session()
     if username or password:
         login_resp = session.post(
             f"{base}/api/v2/auth/login",
@@ -399,10 +401,7 @@ def _add_qbittorrent(url, username, password, download_url, category, download_p
 
 def _add_transmission(url, username, password, download_url, category, download_path, timeout_seconds, expected_name, update_only, exclude_russian, expected_update_number, expected_version):
     base = url.rstrip("/")
-    session = requests.Session()
-    session.headers.update({"User-Agent": DOWNLOADS_USER_AGENT})
-    if username or password:
-        session.auth = (username or "", password or "")
+    session = _new_client_session(username, password)
 
     preflight_files = None
     if update_only:
@@ -512,8 +511,7 @@ def _qb_is_active(item):
 
 def _list_active_qbittorrent(url, username, password, category, download_path, timeout_seconds):
     base = url.rstrip("/")
-    session = requests.Session()
-    session.headers.update({"User-Agent": DOWNLOADS_USER_AGENT})
+    session = _new_client_session()
     if username or password:
         login_resp = session.post(
             f"{base}/api/v2/auth/login",
@@ -577,10 +575,7 @@ _TRANSMISSION_STATUS = {
 
 def _list_active_transmission(url, username, password, category, download_path, timeout_seconds):
     base = url.rstrip("/")
-    session = requests.Session()
-    session.headers.update({"User-Agent": DOWNLOADS_USER_AGENT})
-    if username or password:
-        session.auth = (username or "", password or "")
+    session = _new_client_session(username, password)
 
     payload = {
         "method": "torrent-get",
@@ -690,8 +685,7 @@ def _list_active_deluge(url, password, category, download_path, timeout_seconds)
 
 def _list_completed_qbittorrent(url, username, password, category, download_path, timeout_seconds):
     base = url.rstrip("/")
-    session = requests.Session()
-    session.headers.update({"User-Agent": DOWNLOADS_USER_AGENT})
+    session = _new_client_session()
     if username or password:
         login_resp = session.post(
             f"{base}/api/v2/auth/login",
@@ -749,10 +743,7 @@ def _list_completed_qbittorrent(url, username, password, category, download_path
 
 def _list_completed_transmission(url, username, password, category, download_path, timeout_seconds):
     base = url.rstrip("/")
-    session = requests.Session()
-    session.headers.update({"User-Agent": DOWNLOADS_USER_AGENT})
-    if username or password:
-        session.auth = (username or "", password or "")
+    session = _new_client_session(username, password)
 
     payload = {
         "method": "torrent-get",
@@ -853,8 +844,7 @@ def _is_deluge_managed_label(label):
 
 def _remove_qbittorrent(url, username, password, torrent_hash, timeout_seconds, delete_files=False):
     base = url.rstrip("/")
-    session = requests.Session()
-    session.headers.update({"User-Agent": DOWNLOADS_USER_AGENT})
+    session = _new_client_session()
     if username or password:
         login_resp = session.post(
             f"{base}/api/v2/auth/login",
@@ -886,10 +876,7 @@ def _remove_qbittorrent_with_session(session, base, torrent_hash, timeout_second
 
 def _remove_transmission(url, username, password, torrent_hash, timeout_seconds, delete_files=False):
     base = url.rstrip("/")
-    session = requests.Session()
-    session.headers.update({"User-Agent": DOWNLOADS_USER_AGENT})
-    if username or password:
-        session.auth = (username or "", password or "")
+    session = _new_client_session(username, password)
 
     payload = {
         "method": "torrent-remove",

--- a/app/downloads/update_selection.py
+++ b/app/downloads/update_selection.py
@@ -1,0 +1,51 @@
+import time
+
+from app.downloads.versioning import select_update_file_indices
+
+
+TORRENT_UPDATE_SELECTION_ERROR = "No matching update version found in torrent."
+NZB_UPDATE_SELECTION_ERROR = "No matching update version found in NZB."
+UPDATE_FILE_POLL_ATTEMPTS = 10
+UPDATE_FILE_POLL_INTERVAL_SECONDS = 1
+
+
+def get_matching_update_indices(
+    file_names,
+    expected_update_number=None,
+    expected_version=None,
+    exclude_russian=False,
+):
+    return select_update_file_indices(
+        file_names,
+        expected_update_number=expected_update_number,
+        expected_version=expected_version,
+        exclude_russian=exclude_russian,
+    )
+
+
+def preflight_has_matching_update(
+    file_names,
+    expected_update_number=None,
+    expected_version=None,
+    exclude_russian=False,
+):
+    if file_names is None:
+        return True
+    return bool(
+        get_matching_update_indices(
+            file_names,
+            expected_update_number=expected_update_number,
+            expected_version=expected_version,
+            exclude_russian=exclude_russian,
+        )
+    )
+
+
+def poll_update_file_names(fetch_file_names, attempts=UPDATE_FILE_POLL_ATTEMPTS, sleep_fn=time.sleep):
+    for attempt in range(max(int(attempts), 1)):
+        file_names = list(fetch_file_names() or [])
+        if file_names:
+            return file_names
+        if attempt + 1 < attempts:
+            sleep_fn(UPDATE_FILE_POLL_INTERVAL_SECONDS)
+    return []

--- a/app/downloads/usenet_client.py
+++ b/app/downloads/usenet_client.py
@@ -4,7 +4,11 @@ import time
 
 import requests
 
-from app.downloads.torrent_client import _select_update_file_indices
+from app.downloads.update_selection import (
+    NZB_UPDATE_SELECTION_ERROR,
+    get_matching_update_indices,
+    poll_update_file_names,
+)
 
 logger = logging.getLogger("downloads.sabnzbd")
 
@@ -343,24 +347,22 @@ def _restrict_job_to_matching_update_files(
     expected_update_number=None,
     expected_version=None,
 ):
-    files = []
-    for _ in range(10):
-        files = _get_job_files(url, api_key, nzo_id, timeout_seconds=timeout_seconds)
-        if files:
-            break
-        time.sleep(1)
+    files = poll_update_file_names(
+        lambda: _get_job_files(url, api_key, nzo_id, timeout_seconds=timeout_seconds),
+        sleep_fn=time.sleep,
+    )
     if not files:
         return False, "Unable to resolve SABnzbd file list for update selection."
 
     file_names = [str(item.get("filename") or "") for item in files]
-    keep_indices = _select_update_file_indices(
+    keep_indices = get_matching_update_indices(
         file_names,
         expected_update_number=expected_update_number,
         expected_version=expected_version,
         exclude_russian=exclude_russian,
     )
     if not keep_indices:
-        return False, "No matching update version found in NZB."
+        return False, NZB_UPDATE_SELECTION_ERROR
 
     keep_set = set(keep_indices)
     remove_ids = []

--- a/app/downloads/usenet_client.py
+++ b/app/downloads/usenet_client.py
@@ -4,6 +4,7 @@ import time
 
 import requests
 
+from app.downloads.constants import DOWNLOADS_USER_AGENT
 from app.downloads.update_selection import (
     NZB_UPDATE_SELECTION_ERROR,
     get_matching_update_indices,
@@ -11,9 +12,6 @@ from app.downloads.update_selection import (
 )
 
 logger = logging.getLogger("downloads.sabnzbd")
-
-DOWNLOADS_USER_AGENT = "AeroFoil/Downloads"
-
 
 def test_sabnzbd(url, api_key, timeout_seconds=10):
     if not url:

--- a/app/downloads/versioning.py
+++ b/app/downloads/versioning.py
@@ -1,0 +1,115 @@
+import re
+
+
+def extract_internal_update_version(name):
+    if not name:
+        return None
+    match = re.search(r"\[v(\d+)\]", str(name or ""), re.IGNORECASE)
+    if not match:
+        match = re.search(r"(?<![a-z0-9])v(\d+)(?!\.\d)", str(name or ""), re.IGNORECASE)
+    if not match:
+        return None
+    try:
+        return int(match.group(1))
+    except (TypeError, ValueError):
+        return None
+
+
+def _expected_semantic_version(expected_version):
+    try:
+        value = int(expected_version)
+    except (TypeError, ValueError):
+        return None
+    if value < 0:
+        return None
+    return (
+        (value >> 16) & 0xFFFF,
+        (value >> 8) & 0xFF,
+        value & 0xFF,
+    )
+
+
+def _normalize_semantic_version_parts(parts):
+    values = [int(part) for part in (parts or [])]
+    while len(values) > 3 and values[-1] == 0:
+        values.pop()
+    if len(values) > 3:
+        return None
+    while len(values) < 3:
+        values.append(0)
+    return tuple(values)
+
+
+def _extract_semantic_versions(name):
+    out = []
+    for match in re.finditer(r"(?<![a-z0-9])(\d+(?:\.\d+){1,3})(?![a-z0-9])", str(name or ""), re.IGNORECASE):
+        try:
+            normalized = _normalize_semantic_version_parts(match.group(1).split("."))
+        except (TypeError, ValueError):
+            normalized = None
+        if normalized:
+            out.append(normalized)
+    return out
+
+
+def _collect_update_file_versions(file_entries, exclude_russian=False):
+    internal_versions = []
+    semantic_versions = []
+    for entry_id, raw_name in file_entries or []:
+        name = str(raw_name or "")
+        lowered = name.lower()
+        if exclude_russian and ("russian" in lowered or "rus" in lowered):
+            continue
+        internal_version = extract_internal_update_version(name)
+        if internal_version is not None:
+            internal_versions.append((internal_version, entry_id))
+        for semantic_version in _extract_semantic_versions(name):
+            semantic_versions.append((semantic_version, entry_id))
+    return internal_versions, semantic_versions
+
+
+def select_update_entry_ids(file_entries, expected_update_number=None, expected_version=None, exclude_russian=False):
+    internal_versions, semantic_versions = _collect_update_file_versions(
+        file_entries,
+        exclude_russian=exclude_russian,
+    )
+    expected_value = None
+    if expected_version is not None:
+        try:
+            expected_value = int(expected_version)
+        except (TypeError, ValueError):
+            expected_value = None
+    if expected_value and expected_value > 0:
+        exact_internal = [entry_id for version, entry_id in internal_versions if version == expected_value]
+        if exact_internal:
+            return exact_internal
+        expected_semantic = _expected_semantic_version(expected_value)
+        if expected_semantic:
+            exact_semantic = [entry_id for version, entry_id in semantic_versions if version == expected_semantic]
+            if exact_semantic:
+                return exact_semantic
+    if expected_update_number is not None and expected_update_number > 0:
+        exact_update_number = [
+            entry_id for version, entry_id in internal_versions
+            if (version // 65536) == expected_update_number
+        ]
+        if exact_update_number:
+            return exact_update_number
+    if internal_versions:
+        highest_internal = max(version for version, _entry_id in internal_versions)
+        return [entry_id for version, entry_id in internal_versions if version == highest_internal]
+    if semantic_versions:
+        highest_semantic = max(version for version, _entry_id in semantic_versions)
+        return [entry_id for version, entry_id in semantic_versions if version == highest_semantic]
+    return []
+
+
+def select_update_file_indices(file_names, expected_update_number=None, expected_version=None, exclude_russian=False):
+    if not file_names:
+        return []
+    return select_update_entry_ids(
+        list(enumerate(file_names)),
+        expected_update_number=expected_update_number,
+        expected_version=expected_version,
+        exclude_russian=exclude_russian,
+    )

--- a/app/templates/downloads.html
+++ b/app/templates/downloads.html
@@ -15,7 +15,7 @@
                 <div class="d-flex align-items-center justify-content-between gap-3 flex-wrap">
                     <div>
                         <h2 class="pb-2">Downloads</h2>
-                        <p class="text-muted">Live torrent and usenet status plus the pending AeroFoil download queue.</p>
+                        <p class="text-muted">Live torrent and usenet download status plus the pending AeroFoil queue.</p>
                     </div>
                 </div>
 
@@ -146,9 +146,21 @@
         const state = String(item?.state || 'queued');
         const reason = String(item?.state_reason || '');
         if (state === 'stuck' && reason) {
-            return `stuck: ${reason}`;
+            return `Stuck: ${reason}`;
         }
-        return state;
+        return formatStatusLabel(state);
+    }
+
+    function formatStatusLabel(value) {
+        const text = String(value || '').trim();
+        if (!text) {
+            return '-';
+        }
+        return text
+            .replace(/_/g, ' ')
+            .replace(/\b\w/g, function (match) {
+                return match.toUpperCase();
+            });
     }
 
     function loadQueueState() {
@@ -164,7 +176,7 @@
             const pending = state['pending'] || [];
             const running = state['running'] ? 'running' : 'idle';
             const lastRun = state['last_run'] ? new Date(state['last_run'] * 1000).toLocaleString() : 'never';
-            $('#downloadsQueueStatus').text(`Status: ${running}. Last check: ${lastRun}. Pending: ${pending.length}.`);
+            $('#downloadsQueueStatus').text(`Queue state: ${formatStatusLabel(running)}. Last check: ${lastRun}. Pending: ${pending.length}.`);
             body.empty();
             if (!pending.length) {
                 body.html(`<tr><td colspan="${queueColumnCount}" class="text-muted">No pending downloads.</td></tr>`);
@@ -195,7 +207,7 @@
             showDownloadsAlert('Missing queue key.', 'danger');
             return;
         }
-        if (!window.confirm('Delete this queued download and remove downloader files if possible?')) {
+        if (!window.confirm('Delete this queued download and remove its downloader files if possible?')) {
             return;
         }
         button.prop('disabled', true);
@@ -253,7 +265,7 @@
                     row.append($('<td class="small text-muted"></td>').text((item['protocol'] || '').toString() || '-'));
                 }
                 row.append($('<td class="small text-muted"></td>').text((item['client_type'] || '').toString() || '-'));
-                row.append($('<td class="small text-muted"></td>').text((item['status'] || '').toString()));
+                row.append($('<td class="small text-muted"></td>').text(formatStatusLabel(item['status'])));
                 row.append($('<td class="small"></td>').text(`${progress.toFixed(1)}%`));
                 if (downloadUiVisibility.show_torrent_columns) {
                     row.append($('<td class="small"></td>').text(formatSpeed(item['down_speed'])));

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -350,7 +350,7 @@
                 <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
             </div>
             <div class="modal-body">
-                <div id="torrentSearchStatus" class="text-muted mb-2"></div>
+                <div id="torrentSearchStatus" class="alert alert-info d-none mb-3 py-2 px-3" role="alert"></div>
                 <div class="table-responsive">
                     <table class="table table-sm table-striped align-middle">
                         <thead>
@@ -1291,6 +1291,7 @@
         const actionCell = $('<td></td>');
         const button = $('<button type="button" class="btn btn-sm btn-warning queue-download-btn"></button>');
         button.text(actionLabel);
+        button.attr('data-action-label', String(actionLabel || 'Queue'));
         button.attr('data-download-url', String(item?.download_url || ''));
         button.attr('data-title', String(item?.title || ''));
         button.attr('data-protocol', String(item?.protocol || ''));
@@ -1309,23 +1310,35 @@
             .addClass(`text-${tone}`);
     }
 
+    function setTorrentSearchStatus(message, tone = 'info') {
+        const status = $('#torrentSearchStatus');
+        if (!message) {
+            status.addClass('d-none').text('');
+            return;
+        }
+        status
+            .text(message)
+            .removeClass('d-none alert-info alert-success alert-warning alert-danger')
+            .addClass(`alert-${tone}`);
+    }
+
     function showTorrentSearchModal(statusMessage = 'Searching Prowlarr...') {
-        $('#torrentSearchStatus').text(statusMessage);
+        setTorrentSearchStatus(statusMessage, 'info');
         $('#torrentSearchResults').empty();
         bootstrap.Modal.getOrCreateInstance(document.getElementById('torrentSearchModal')).show();
     }
 
     function renderDownloadSearchResults(result, actionLabel, buildExtraData) {
         if (!result['success']) {
-            $('#torrentSearchStatus').text(result['message'] || 'Search failed.');
+            setTorrentSearchStatus(result['message'] || 'Search failed.', 'danger');
             return;
         }
         const results = result['results'] || [];
         if (!results.length) {
-            $('#torrentSearchStatus').text('No results found.');
+            setTorrentSearchStatus('No results found.', 'warning');
             return;
         }
-        $('#torrentSearchStatus').text(`Found ${results.length} results.`);
+        setTorrentSearchStatus(`Found ${results.length} results.`, 'info');
         results.forEach(item => {
             const row = buildDownloadSearchRow(item, actionLabel, buildExtraData(item));
             $('#torrentSearchResults').append(row);
@@ -1855,21 +1868,21 @@
                 if (!query) {
                     return;
                 }
-                $('#torrentSearchStatus').text('Searching Prowlarr...');
+                setTorrentSearchStatus('Searching Prowlarr...', 'info');
                 $('#torrentSearchResults').empty();
                 const modal = new bootstrap.Modal(document.getElementById('torrentSearchModal'));
                 modal.show();
                 $.getJSON(`/api/downloads/search?query=${encodeURIComponent(query)}&apply_settings=1`, function (result) {
                     if (!result['success']) {
-                        $('#torrentSearchStatus').text(result['message'] || 'Search failed.');
+                        setTorrentSearchStatus(result['message'] || 'Search failed.', 'danger');
                         return;
                     }
                     const results = result['results'] || [];
                     if (!results.length) {
-                        $('#torrentSearchStatus').text('No results found.');
+                        setTorrentSearchStatus('No results found.', 'warning');
                         return;
                     }
-                    $('#torrentSearchStatus').text(`Found ${results.length} results.`);
+                    setTorrentSearchStatus(`Found ${results.length} results.`, 'info');
                     results.forEach(item => {
                         const row = buildDownloadSearchRow(item, 'Queue');
                         $('#torrentSearchResults').append(row);
@@ -1879,17 +1892,21 @@
 
         $(document).on('click', '.queue-download-btn', function () {
             const button = $(this);
+            if (button.prop('disabled') || button.data('queued') === true) {
+                return;
+            }
             const downloadUrl = button.data('download-url');
             const title = button.data('title');
             const titleId = button.data('title-id');
             const protocol = button.data('protocol');
             const updateOnly = button.data('update-only') === true || button.data('update-only') === 'true';
             const expectedVersion = button.data('expected-version');
+            const originalLabel = String(button.attr('data-action-label') || button.text() || 'Queue');
             if (!downloadUrl) {
                 return;
             }
-            button.prop('disabled', true);
-            $('#torrentSearchStatus').text('Queuing download...');
+            button.prop('disabled', true).text('Queuing...');
+            setTorrentSearchStatus('Queuing download...', 'info');
             $.ajax({
                 url: "/api/downloads/queue",
                 type: 'POST',
@@ -1904,13 +1921,30 @@
                 contentType: "application/json",
                 success: function (result) {
                     const ok = result['success'];
-                        $('#torrentSearchStatus').text(result['message'] || (ok ? 'Queued download.' : 'Queue failed.'));
-                    },
-                    complete: function () {
+                    if (ok) {
+                        button
+                            .data('queued', true)
+                            .removeClass('btn-warning')
+                            .addClass('btn-success')
+                            .text('Queued')
+                            .prop('disabled', true);
+                        setTorrentSearchStatus(result['message'] || 'Download queued successfully.', 'success');
+                        return;
+                    }
+                    button.text(originalLabel);
+                    setTorrentSearchStatus(result['message'] || 'Queue failed.', 'danger');
+                },
+                error: function () {
+                    button.text(originalLabel);
+                    setTorrentSearchStatus('Queue failed.', 'danger');
+                },
+                complete: function () {
+                    if (button.data('queued') !== true) {
                         button.prop('disabled', false);
                     }
-                });
+                }
             });
+        });
         }
 
         // Close popovers

--- a/app/templates/requests.html
+++ b/app/templates/requests.html
@@ -13,8 +13,8 @@
             <h2 class="pb-2">Requests</h2>
             <p class="text-muted">User title requests and download search.</p>
             {% else %}
-            <h2 class="pb-2">Request A Title</h2>
-            <p class="text-muted">Search TitleDB and request content not yet in your library.</p>
+            <h2 class="pb-2">Request a Title</h2>
+            <p class="text-muted">Search TitleDB and request content that is not yet in your library.</p>
             {% endif %}
           </div>
           <div class="d-flex align-items-center gap-2">

--- a/app/templates/settings.html
+++ b/app/templates/settings.html
@@ -546,8 +546,8 @@
                                     <select id="selectLanguage" class="form-select" aria-label="Select library language">
                                     </select>
                                 </div>
-                                <div id="selectRegionLanguageHelp" class="form-text">Region and Language used to get games
-                                    informations.</div>
+                                <div id="selectRegionLanguageHelp" class="form-text">Region and language used to retrieve game
+                                    information.</div>
                             </div>
                         </div>
 

--- a/app/templates/users.html
+++ b/app/templates/users.html
@@ -1108,7 +1108,7 @@
             const modalBody = deleteUserModal.find('.modal-body')
             const deleteBtn = deleteUserModal.find('.btn-danger')
             deleteBtn.attr('onClick', 'deleteUser(' + id + ');');
-            modalBody.text("Delete user " + user + " ?")
+            modalBody.text("Delete user " + user + "?")
         })
     }
 

--- a/tests/test_download_clients.py
+++ b/tests/test_download_clients.py
@@ -947,6 +947,26 @@ class SabSelectionTests(unittest.TestCase):
         delete_job_files_mock.assert_called_once()
         self.assertEqual(delete_job_files_mock.call_args.args[3], ["1"])
 
+    @patch("app.downloads.usenet_client._delete_job_files", return_value=True)
+    @patch("app.downloads.usenet_client._get_job_files")
+    def test_restrict_job_matches_semantic_version_when_internal_tag_missing(self, get_job_files_mock, delete_job_files_mock):
+        get_job_files_mock.return_value = [
+            {"filename": "Game Update 1.0.0.nsp", "nzf_id": "1"},
+            {"filename": "Game Update 1.1.0.nsp", "nzf_id": "2"},
+        ]
+
+        ok, message = _restrict_job_to_matching_update_files(
+            "http://sab.local",
+            "secret",
+            "nzo123",
+            expected_version=65792,
+        )
+
+        self.assertTrue(ok)
+        self.assertIsNone(message)
+        delete_job_files_mock.assert_called_once()
+        self.assertEqual(delete_job_files_mock.call_args.args[3], ["1"])
+
     @patch("app.downloads.usenet_client._delete_job")
     @patch("app.downloads.usenet_client._resume_job", return_value=False)
     @patch("app.downloads.usenet_client._restrict_job_to_matching_update_files", return_value=(True, None))

--- a/tests/test_download_clients.py
+++ b/tests/test_download_clients.py
@@ -920,6 +920,35 @@ class QueueRoutingTests(unittest.TestCase):
         self.assertTrue(add_nzb_mock.call_args.kwargs["exclude_russian"])
         self.assertEqual(add_nzb_mock.call_args.kwargs["expected_version"], 123)
 
+    @patch("app.downloads.client.add_torrent")
+    def test_queue_download_routes_by_client_type_when_protocol_missing(self, add_torrent_mock):
+        add_torrent_mock.return_value = (True, "ok", "abc123")
+
+        ok, message, item_id = queue_download(
+            "",
+            {
+                "type": "qbittorrent",
+                "url": "http://torrent.local",
+                "username": "user",
+                "password": "pass",
+                "category": "aerofoil",
+                "download_path": "X:\\fixture-root\\downloads",
+            },
+            "magnet:?xt=urn:btih:abcdef",
+            expected_name="Game Update",
+            update_only=True,
+            exclude_russian=True,
+            expected_version=123,
+        )
+
+        self.assertTrue(ok)
+        self.assertEqual(message, "ok")
+        self.assertEqual(item_id, "abc123")
+        add_torrent_mock.assert_called_once()
+        self.assertEqual(add_torrent_mock.call_args.kwargs["client_type"], "qbittorrent")
+        self.assertEqual(add_torrent_mock.call_args.kwargs["download_path"], "X:\\fixture-root\\downloads")
+        self.assertTrue(add_torrent_mock.call_args.kwargs["update_only"])
+
 
 class SabSelectionTests(unittest.TestCase):
     @patch("app.downloads.usenet_client.time.sleep")

--- a/tests/test_downloads_qbittorrent_add.py
+++ b/tests/test_downloads_qbittorrent_add.py
@@ -21,11 +21,13 @@ class _FakeResponse:
 
 
 class _FakeSession:
-    def __init__(self, add_text="Ok.", info_by_hash=None, managed_items=None):
+    def __init__(self, add_text="Ok.", info_by_hash=None, managed_items=None, files_by_hash=None):
         self.headers = {}
         self._add_text = add_text
         self._info_by_hash = dict(info_by_hash or {})
         self._managed_items = list(managed_items or [])
+        self._files_by_hash = dict(files_by_hash or {})
+        self.file_prio_calls = []
 
     def post(self, url, data=None, timeout=None):
         if url.endswith("/api/v2/auth/login"):
@@ -37,6 +39,7 @@ class _FakeSession:
         if url.endswith("/api/v2/torrents/resume"):
             return _FakeResponse(status_code=200, text="")
         if url.endswith("/api/v2/torrents/filePrio"):
+            self.file_prio_calls.append(dict(data or {}))
             return _FakeResponse(status_code=200, text="")
         if url.endswith("/api/v2/torrents/delete"):
             return _FakeResponse(status_code=200, text="")
@@ -52,7 +55,8 @@ class _FakeSession:
                 return _FakeResponse(status_code=200, json_data=[])
             return _FakeResponse(status_code=200, json_data=list(self._managed_items))
         if url.endswith("/api/v2/torrents/files"):
-            return _FakeResponse(status_code=200, json_data=[])
+            lookup = str((params or {}).get("hash") or "").lower()
+            return _FakeResponse(status_code=200, json_data=list(self._files_by_hash.get(lookup, [])))
         return _FakeResponse(status_code=404, json_data=[])
 
 
@@ -144,6 +148,43 @@ class QBittorrentAddTests(unittest.TestCase):
         self.assertFalse(ok)
         self.assertIn("rejected", message.lower())
         self.assertIsNone(torrent_hash)
+
+    def test_select_update_file_indices_matches_semantic_version_when_internal_tag_missing(self):
+        selected = torrent_client._select_update_file_indices(
+            [
+                "Example Title Update 1.0.0.nsp",
+                "Example Title Update 1.1.0.nsp",
+            ],
+            expected_version=65792,
+        )
+
+        self.assertEqual(selected, [1])
+
+    def test_select_qbittorrent_highest_version_matches_semantic_version_when_internal_tag_missing(self):
+        torrent_hash = "abc123"
+        fake_session = _FakeSession(
+            files_by_hash={
+                torrent_hash: [
+                    {"index": 0, "name": "Example Title Update 1.0.0.nsp", "priority": 1},
+                    {"index": 1, "name": "Example Title Update 1.1.0.nsp", "priority": 1},
+                ]
+            }
+        )
+
+        ok = torrent_client._select_qbittorrent_highest_version(
+            fake_session,
+            self.base_url,
+            torrent_hash,
+            timeout_seconds=1,
+            exclude_russian=False,
+            expected_version=65792,
+        )
+
+        self.assertTrue(ok)
+        self.assertEqual(fake_session.file_prio_calls[0]["id"], "0|1")
+        self.assertEqual(fake_session.file_prio_calls[0]["priority"], 0)
+        self.assertEqual(fake_session.file_prio_calls[1]["id"], "1")
+        self.assertEqual(fake_session.file_prio_calls[1]["priority"], 1)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- fix update-only downloads when release filenames expose semantic versions like `1.1.0` instead of only internal `[v123456]` tokens
- add regression coverage for torrent and usenet update file selection
- follow up with small download-client refactors to centralize update selection helpers, routing helpers, shared constants, and repeated qBittorrent/Transmission request setup
- improve download search feedback and clean up user-facing template copy/status formatting

## User-visible impact
- update downloads for issue #87 can now match semantic-versioned release filenames during torrent and NZB file selection
- download search feedback is clearer in the library details modal
- downloads/settings/request/users template copy is more consistent and status labels are normalized
- no config or migration changes are required

## Validation
- `python -m unittest tests.test_download_clients`
- `python -m unittest tests.test_downloads_qbittorrent_add`
- `python -m unittest tests.test_download_protocols`
- template copy/status cleanup verified by readback only; no additional tests were run for those UI-only changes

## Notes
- branch created from `upstream/dev`
- related issue: #87