### PR TITLE
fix: add built-in metadata for port titles

### DIFF
--- a/app/constants.py
+++ b/app/constants.py
@@ -161,6 +161,23 @@ DEFAULT_SETTINGS = {
     }
 }
 
+BUILTIN_TITLE_MANUAL_OVERRIDES = {
+    "018FCC923D8D0000": {
+        "name": "The Simpsons: Hit & Run [Port]",
+        "description": "Community port of The Simpsons: Hit & Run for Nintendo Switch. Requires the original Windows game files to run.",
+        "iconUrl": "https://static.simpsonswiki.com/images/5/5f/The_Simpsons_Hit_and_Run_cover.png",
+        "bannerUrl": "https://static.simpsonswiki.com/images/5/5f/The_Simpsons_Hit_and_Run_cover.png",
+        "screenshots": [],
+    },
+    "056783A0CC4A0000": {
+        "name": "Ship of Harkinian",
+        "description": "Open-source port of The Legend of Zelda: Ocarina of Time with modern enhancements for Nintendo Switch and other platforms.",
+        "iconUrl": "https://raw.githubusercontent.com/HarbourMasters/shipofharkinian.com/9c5639c054cb3bc952760758307473a3e425fd33/public/logo.png",
+        "bannerUrl": "https://raw.githubusercontent.com/HarbourMasters/shipofharkinian.com/9c5639c054cb3bc952760758307473a3e425fd33/public/splash_poster.jpg",
+        "screenshots": [],
+    },
+}
+
 TINFOIL_HEADERS = [
     'Theme',
     'Uid',

--- a/app/constants.py
+++ b/app/constants.py
@@ -176,6 +176,20 @@ BUILTIN_TITLE_MANUAL_OVERRIDES = {
         "bannerUrl": "https://raw.githubusercontent.com/HarbourMasters/shipofharkinian.com/9c5639c054cb3bc952760758307473a3e425fd33/public/splash_poster.jpg",
         "screenshots": [],
     },
+    "0500D22512158000": {
+        "name": "Sonic Dimensions",
+        "description": "Fan-made homebrew port of the 2D Sonic fangame Sonic Dimensions for Nintendo Switch.",
+        "iconUrl": "https://dlhb.gamebrew.org/switchhomebrews/images/SonicDimensionsSwitch-01.png",
+        "bannerUrl": "https://dlhb.gamebrew.org/switchhomebrews/images/SonicDimensionsSwitch-02.png",
+        "screenshots": [],
+    },
+    "010CAF78CF713000": {
+        "name": "The Legend of Zelda - A Link to the Past",
+        "description": "Community homebrew port of The Legend of Zelda: A Link to the Past for Nintendo Switch with quality-of-life and widescreen enhancements.",
+        "iconUrl": "https://dlhb.gamebrew.org/switchhomebrews/images/zeldalinktothepastnx2.png",
+        "bannerUrl": "https://dlhb.gamebrew.org/switchhomebrews/images/zeldalinktothepastnx3.png",
+        "screenshots": [],
+    },
     # Unverified port candidates, add only after confirming the Switch NSP app ID:
     # "TODO_APP_ID_2SHIP2HARKINIAN": {
     #     "name": "2 Ship 2 Harkinian",
@@ -189,13 +203,6 @@ BUILTIN_TITLE_MANUAL_OVERRIDES = {
     #     "description": "Community port of Star Fox 64 for Nintendo Switch.",
     #     "iconUrl": "https://raw.githubusercontent.com/HarbourMasters/Starship/62eb5a198bc5a8806f8c1b43551cd689e929455e/logo.png",
     #     "bannerUrl": "https://raw.githubusercontent.com/HarbourMasters/Starship/62eb5a198bc5a8806f8c1b43551cd689e929455e/nx-logo.jpg",
-    #     "screenshots": [],
-    # },
-    # "TODO_APP_ID_ALTTP": {
-    #     "name": "The Legend of Zelda - A Link to the Past",
-    #     "description": "Community port of The Legend of Zelda: A Link to the Past for Nintendo Switch.",
-    #     "iconUrl": "",
-    #     "bannerUrl": "",
     #     "screenshots": [],
     # },
     # "TODO_APP_ID_SUPER_METROID_SWITCH": {

--- a/app/constants.py
+++ b/app/constants.py
@@ -176,6 +176,35 @@ BUILTIN_TITLE_MANUAL_OVERRIDES = {
         "bannerUrl": "https://raw.githubusercontent.com/HarbourMasters/shipofharkinian.com/9c5639c054cb3bc952760758307473a3e425fd33/public/splash_poster.jpg",
         "screenshots": [],
     },
+    # Unverified port candidates, add only after confirming the Switch NSP app ID:
+    # "TODO_APP_ID_2SHIP2HARKINIAN": {
+    #     "name": "2 Ship 2 Harkinian",
+    #     "description": "Community port of The Legend of Zelda: Majora's Mask for Nintendo Switch.",
+    #     "iconUrl": "https://github.com/user-attachments/assets/a12851e2-1eb7-428c-973c-86fdfad73dd3",
+    #     "bannerUrl": "https://github.com/user-attachments/assets/a12851e2-1eb7-428c-973c-86fdfad73dd3",
+    #     "screenshots": [],
+    # },
+    # "TODO_APP_ID_STARSHIP": {
+    #     "name": "Starship",
+    #     "description": "Community port of Star Fox 64 for Nintendo Switch.",
+    #     "iconUrl": "https://raw.githubusercontent.com/HarbourMasters/Starship/62eb5a198bc5a8806f8c1b43551cd689e929455e/logo.png",
+    #     "bannerUrl": "https://raw.githubusercontent.com/HarbourMasters/Starship/62eb5a198bc5a8806f8c1b43551cd689e929455e/nx-logo.jpg",
+    #     "screenshots": [],
+    # },
+    # "TODO_APP_ID_ALTTP": {
+    #     "name": "The Legend of Zelda - A Link to the Past",
+    #     "description": "Community port of The Legend of Zelda: A Link to the Past for Nintendo Switch.",
+    #     "iconUrl": "",
+    #     "bannerUrl": "",
+    #     "screenshots": [],
+    # },
+    # "TODO_APP_ID_SUPER_METROID_SWITCH": {
+    #     "name": "Super Metroid Switch",
+    #     "description": "Community port of Super Metroid for Nintendo Switch.",
+    #     "iconUrl": "",
+    #     "bannerUrl": "",
+    #     "screenshots": [],
+    # },
 }
 
 TINFOIL_HEADERS = [

--- a/app/settings.py
+++ b/app/settings.py
@@ -140,6 +140,17 @@ def _normalize_titles_manual_overrides(raw_overrides):
         }
     return out
 
+
+def _get_built_in_titles_manual_overrides():
+    return _normalize_titles_manual_overrides(BUILTIN_TITLE_MANUAL_OVERRIDES)
+
+
+def _merge_titles_manual_overrides(raw_overrides):
+    merged = _get_built_in_titles_manual_overrides()
+    merged.update(_normalize_titles_manual_overrides(raw_overrides))
+    return merged
+
+
 def _normalize_titles_settings(raw_titles):
     defaults = DEFAULT_SETTINGS.get('titles', {}) or {}
     merged = defaults.copy()
@@ -154,9 +165,9 @@ def _normalize_titles_settings(raw_titles):
         merged.get('prefer_english_metadata'),
         default=defaults.get('prefer_english_metadata', False),
     )
-    merged['manual_overrides'] = _normalize_titles_manual_overrides(
-        merged.get('manual_overrides')
-    )
+    user_overrides = _normalize_titles_manual_overrides(merged.get('manual_overrides'))
+    merged['manual_overrides'] = user_overrides
+    merged['effective_manual_overrides'] = _merge_titles_manual_overrides(user_overrides)
     return merged
 
 def _normalize_library_naming_templates(raw_templates):

--- a/app/titles.py
+++ b/app/titles.py
@@ -1263,7 +1263,20 @@ def identify_file(filepath):
 def _get_manual_title_override(title_id):
     try:
         settings = load_settings()
-        overrides = (settings.get('titles') or {}).get('manual_overrides') or {}
+        title_settings = settings.get('titles') or {}
+        overrides = title_settings.get('effective_manual_overrides')
+        if not isinstance(overrides, dict):
+            overrides = {}
+            for raw_overrides in (
+                BUILTIN_TITLE_MANUAL_OVERRIDES,
+                title_settings.get('manual_overrides') or {},
+            ):
+                if not isinstance(raw_overrides, dict):
+                    continue
+                for key, value in raw_overrides.items():
+                    normalized_key = str(key or '').strip().upper()
+                    if normalized_key and isinstance(value, dict):
+                        overrides[normalized_key] = value
         return overrides.get(str(title_id or '').strip().upper()) or {}
     except Exception:
         return {}

--- a/tests/test_titles_language_preference.py
+++ b/tests/test_titles_language_preference.py
@@ -3,6 +3,7 @@ from unittest.mock import patch
 
 from app import settings
 from app import titles
+from app.constants import BUILTIN_TITLE_MANUAL_OVERRIDES
 
 
 class TitlesLanguagePreferenceTests(unittest.TestCase):
@@ -105,6 +106,116 @@ class TitlesLanguagePreferenceTests(unittest.TestCase):
         self.assertEqual(normalized['language'], 'ja')
         self.assertTrue(normalized['prefer_english_metadata'])
         self.assertEqual(normalized['manual_overrides'], {})
+
+    def test_normalize_titles_settings_merges_built_in_and_user_overrides(self):
+        normalized = settings._normalize_titles_settings({
+            'manual_overrides': {
+                '0100DEADBEEF0000': {
+                    'name': 'Example Custom Title',
+                },
+            },
+        })
+
+        self.assertEqual(normalized['manual_overrides'], {
+            '0100DEADBEEF0000': {
+                'name': 'Example Custom Title',
+                'description': '',
+                'iconUrl': '',
+                'bannerUrl': '',
+                'screenshots': [],
+            },
+        })
+        self.assertEqual(
+            normalized['effective_manual_overrides']['018FCC923D8D0000']['name'],
+            BUILTIN_TITLE_MANUAL_OVERRIDES['018FCC923D8D0000']['name'],
+        )
+        self.assertTrue(normalized['effective_manual_overrides']['018FCC923D8D0000']['description'])
+        self.assertTrue(normalized['effective_manual_overrides']['018FCC923D8D0000']['iconUrl'])
+        self.assertTrue(normalized['effective_manual_overrides']['018FCC923D8D0000']['bannerUrl'])
+        self.assertEqual(
+            normalized['effective_manual_overrides']['056783A0CC4A0000']['name'],
+            BUILTIN_TITLE_MANUAL_OVERRIDES['056783A0CC4A0000']['name'],
+        )
+        self.assertTrue(normalized['effective_manual_overrides']['056783A0CC4A0000']['description'])
+        self.assertTrue(normalized['effective_manual_overrides']['056783A0CC4A0000']['iconUrl'])
+        self.assertTrue(normalized['effective_manual_overrides']['056783A0CC4A0000']['bannerUrl'])
+        self.assertEqual(
+            normalized['effective_manual_overrides']['0100DEADBEEF0000']['name'],
+            'Example Custom Title',
+        )
+
+    def test_get_game_info_returns_built_in_override_for_unknown_simpsons_port(self):
+        title_id = '018FCC923D8D0000'
+
+        with patch(
+            'app.titles.load_settings',
+            return_value={'titles': {'manual_overrides': {}}},
+        ), patch(
+            'app.titles._get_title_info_from_index',
+            return_value=None,
+        ):
+            info = titles.get_game_info(title_id)
+
+        self.assertEqual(info['name'], 'The Simpsons: Hit & Run [Port]')
+        self.assertEqual(info['id'], f'{title_id} not found in titledb')
+        self.assertTrue(info['description'])
+        self.assertTrue(info['iconUrl'])
+        self.assertTrue(info['bannerUrl'])
+
+    def test_get_game_info_prefers_user_override_over_built_in_override(self):
+        title_id = '018FCC923D8D0000'
+
+        with patch(
+            'app.titles.load_settings',
+            return_value={
+                'titles': {
+                    'manual_overrides': {
+                        title_id: {
+                            'name': 'My Simpsons Port Name',
+                        },
+                    },
+                },
+            },
+        ), patch(
+            'app.titles._get_title_info_from_index',
+            return_value=None,
+        ):
+            info = titles.get_game_info(title_id)
+
+        self.assertEqual(info['name'], 'My Simpsons Port Name')
+
+    def test_get_game_info_returns_built_in_override_for_unknown_ship_of_harkinian_port(self):
+        title_id = '056783A0CC4A0000'
+
+        with patch(
+            'app.titles.load_settings',
+            return_value={'titles': {'manual_overrides': {}}},
+        ), patch(
+            'app.titles._get_title_info_from_index',
+            return_value=None,
+        ):
+            info = titles.get_game_info(title_id)
+
+        self.assertEqual(info['name'], 'Ship of Harkinian')
+        self.assertEqual(info['id'], f'{title_id} not found in titledb')
+        self.assertTrue(info['description'])
+        self.assertTrue(info['iconUrl'])
+        self.assertTrue(info['bannerUrl'])
+
+    def test_get_game_info_leaves_other_unknown_titles_unrecognized(self):
+        title_id = '0BADF00D0BADF00D'
+
+        with patch(
+            'app.titles.load_settings',
+            return_value={'titles': {'manual_overrides': {}}},
+        ), patch(
+            'app.titles._get_title_info_from_index',
+            return_value=None,
+        ):
+            info = titles.get_game_info(title_id)
+
+        self.assertEqual(info['name'], 'Unrecognized')
+        self.assertEqual(info['id'], f'{title_id} not found in titledb')
 
 
 if __name__ == '__main__':

--- a/tests/test_titles_language_preference.py
+++ b/tests/test_titles_language_preference.py
@@ -140,6 +140,20 @@ class TitlesLanguagePreferenceTests(unittest.TestCase):
         self.assertTrue(normalized['effective_manual_overrides']['056783A0CC4A0000']['iconUrl'])
         self.assertTrue(normalized['effective_manual_overrides']['056783A0CC4A0000']['bannerUrl'])
         self.assertEqual(
+            normalized['effective_manual_overrides']['0500D22512158000']['name'],
+            BUILTIN_TITLE_MANUAL_OVERRIDES['0500D22512158000']['name'],
+        )
+        self.assertTrue(normalized['effective_manual_overrides']['0500D22512158000']['description'])
+        self.assertTrue(normalized['effective_manual_overrides']['0500D22512158000']['iconUrl'])
+        self.assertTrue(normalized['effective_manual_overrides']['0500D22512158000']['bannerUrl'])
+        self.assertEqual(
+            normalized['effective_manual_overrides']['010CAF78CF713000']['name'],
+            BUILTIN_TITLE_MANUAL_OVERRIDES['010CAF78CF713000']['name'],
+        )
+        self.assertTrue(normalized['effective_manual_overrides']['010CAF78CF713000']['description'])
+        self.assertTrue(normalized['effective_manual_overrides']['010CAF78CF713000']['iconUrl'])
+        self.assertTrue(normalized['effective_manual_overrides']['010CAF78CF713000']['bannerUrl'])
+        self.assertEqual(
             normalized['effective_manual_overrides']['0100DEADBEEF0000']['name'],
             'Example Custom Title',
         )
@@ -197,6 +211,42 @@ class TitlesLanguagePreferenceTests(unittest.TestCase):
             info = titles.get_game_info(title_id)
 
         self.assertEqual(info['name'], 'Ship of Harkinian')
+        self.assertEqual(info['id'], f'{title_id} not found in titledb')
+        self.assertTrue(info['description'])
+        self.assertTrue(info['iconUrl'])
+        self.assertTrue(info['bannerUrl'])
+
+    def test_get_game_info_returns_built_in_override_for_unknown_sonic_dimensions_port(self):
+        title_id = '0500D22512158000'
+
+        with patch(
+            'app.titles.load_settings',
+            return_value={'titles': {'manual_overrides': {}}},
+        ), patch(
+            'app.titles._get_title_info_from_index',
+            return_value=None,
+        ):
+            info = titles.get_game_info(title_id)
+
+        self.assertEqual(info['name'], 'Sonic Dimensions')
+        self.assertEqual(info['id'], f'{title_id} not found in titledb')
+        self.assertTrue(info['description'])
+        self.assertTrue(info['iconUrl'])
+        self.assertTrue(info['bannerUrl'])
+
+    def test_get_game_info_returns_built_in_override_for_unknown_alttp_port(self):
+        title_id = '010CAF78CF713000'
+
+        with patch(
+            'app.titles.load_settings',
+            return_value={'titles': {'manual_overrides': {}}},
+        ), patch(
+            'app.titles._get_title_info_from_index',
+            return_value=None,
+        ):
+            info = titles.get_game_info(title_id)
+
+        self.assertEqual(info['name'], 'The Legend of Zelda - A Link to the Past')
         self.assertEqual(info['id'], f'{title_id} not found in titledb')
         self.assertTrue(info['description'])
         self.assertTrue(info['iconUrl'])


### PR DESCRIPTION
## Summary
- add built-in manual title overrides for known Switch port title IDs so they resolve to recognizable names and artwork even when TitleDB has no entry
- merge built-in overrides with user-configured title overrides while preserving user overrides as the higher-priority source
- add focused tests covering override normalization, built-in fallback behavior, and user-override precedence

## User-visible impact
- known port titles such as The Simpsons: Hit & Run [Port], Ship of Harkinian, Sonic Dimensions, and The Legend of Zelda - A Link to the Past no longer appear as unrecognized when TitleDB lacks metadata
- existing manual overrides in settings still win over the built-in defaults

## Config and migration
- no migration required
- no new config required

## Testing
- `python -m unittest tests.test_titles_language_preference`
