### PR TITLE
Fix: Filename identification misclassifies UPDATE/DLC files as BASE

### DIFF
--- a/app/library.py
+++ b/app/library.py
@@ -512,10 +512,44 @@ def identify_library_files(library):
             processed=processed
         )
 
+def _cleanup_phantom_base_apps():
+    """Remove BASE-type apps that were incorrectly created by filename identification.
+
+    When filename-based identification encounters an update file whose name
+    contains the title_id (ending in 000) rather than the update app_id
+    (ending in 800), it misclassifies the file as a BASE app.  After a
+    subsequent CNMT-based rescan creates the correct UPDATE entry, the
+    phantom BASE row remains in the database with no linked files and
+    owned=False.  This function removes those orphans.
+    """
+    has_files = (
+        db.session.query(app_files.c.app_id)
+        .filter(app_files.c.app_id == Apps.id)
+        .exists()
+    )
+    deleted = (
+        db.session.query(Apps)
+        .filter(
+            Apps.app_type == APP_TYPE_BASE,
+            Apps.owned.is_(False),
+            ~has_files,
+            Apps.app_version != '0',
+        )
+        .delete(synchronize_session=False)
+    )
+    if deleted:
+        db.session.commit()
+        logger.info("Removed %d phantom BASE app entries (no files, not owned, version != 0).", deleted)
+    return deleted
+
 def add_missing_apps_to_db():
     phase = 'add_missing_apps_to_db'
     _diag_phase_start(phase)
     logger.info('Adding missing apps to database...')
+
+    # Clean up phantom BASE entries from previous filename mis-identification.
+    _cleanup_phantom_base_apps()
+
     apps_added = 0
     processed = 0
     last_title_pk = 0

--- a/app/titles.py
+++ b/app/titles.py
@@ -97,6 +97,7 @@ def keys_loaded():
 
 app_id_regex = r"\[([0-9A-Fa-f]{16})\]"
 version_regex = r"\[v(\d+)\]"
+type_tag_regex = r"\[(BASE|UPDATE|DLC)\]"
 
 # Global variables for TitleDB data
 identification_in_progress_count = 0
@@ -1168,6 +1169,19 @@ def unload_titledb():
             _local_file_metadata_cache.clear()
         logger.info("TitleDBs unloaded.")
 
+def get_type_tag_from_filename(filename):
+    type_tag_match = re.search(type_tag_regex, filename, re.IGNORECASE)
+    if type_tag_match is None:
+        return None
+    tag = type_tag_match[1].upper()
+    if tag == 'BASE':
+        return APP_TYPE_BASE
+    elif tag == 'UPDATE':
+        return APP_TYPE_UPD
+    elif tag == 'DLC':
+        return APP_TYPE_DLC
+    return None
+
 def identify_file_from_filename(filename):
     title_id = None
     app_id = None
@@ -1180,6 +1194,25 @@ def identify_file_from_filename(filename):
         errors.append('Could not determine App ID from filename, pattern [APPID] not found. Title ID and Type cannot be derived.')
     else:
         title_id, app_type = identify_appId(app_id)
+
+
+    # Check for explicit [BASE], [UPDATE], or [DLC] type tags in the filename.
+    # Naming conventions typically embed the title_id (ending in 000) rather than
+    # the app_id, so the ID-based type detection can misclassify UPDATE/DLC files
+    # as BASE.  The explicit tag takes precedence when present.
+    filename_type_tag = get_type_tag_from_filename(filename)
+    if filename_type_tag is not None and app_id is not None:
+        if filename_type_tag != app_type:
+            if filename_type_tag == APP_TYPE_UPD:
+                # Derive the correct update app_id from the title_id
+                base_id = (title_id or app_id)
+                app_id = base_id[:-3] + '800'
+                title_id = base_id[:-3] + '000'
+            elif filename_type_tag == APP_TYPE_DLC and app_type == APP_TYPE_BASE:
+                # DLC app_id can't be reliably derived from title_id alone;
+                # keep the extracted ID but correct the type.
+                title_id = get_title_id_from_app_id(app_id, APP_TYPE_DLC) if not app_id.endswith('000') else app_id
+            app_type = filename_type_tag
 
     version = get_version_from_filename(filename)
     if version is None:


### PR DESCRIPTION
### Problem

When filename-based identification is used (keys not loaded or CNMT unavailable), `identify_file_from_filename` extracts the 16-char hex ID from brackets and uses its last 3 characters to determine the app type (`000` = BASE, `800` = UPDATE, else DLC).

However, common naming conventions (including AeroFoil's own default naming template) embed the **title_id** (always ending in `000`) in filenames rather than the actual **app_id**. This causes UPDATE and DLC files to be misclassified as BASE apps.

**Example:** `Balatro [0100CD801CE5E000] [UPDATE][v851968].nsp` — the ID ends in `000`, so filename identification creates a BASE entry with version 851968. After a subsequent CNMT-based rescan creates the correct UPDATE entry, the phantom BASE row persists because it has a unique `(app_id, version)` pair. This results in duplicate entries in the UI — one "In Library" BASE and one "Missing" BASE at the update version.

### Fix

**`app/titles.py`:**
- Add `type_tag_regex` to parse explicit `[BASE]`, `[UPDATE]`, `[DLC]` tags from filenames
- `identify_file_from_filename` now uses these tags to override ID-based type classification
- When an `[UPDATE]` tag is found, the correct update app_id (ending `800`) is derived from the title_id

**`app/library.py`:**
- Add `_cleanup_phantom_base_apps()` to remove orphaned BASE entries left behind by previous mis-identification (not owned, no linked files, version != 0)
- Called automatically at the start of `add_missing_apps_to_db()` to self-heal existing databases

### Testing

Verified on a live instance with 155+ games. Before fix: 59 phantom BASE entries across the library. After fix: 0 phantom entries, all titles display as single entries with correct type classification.