### PR TITLE
fix(utils): ignore hidden dotfiles and macOS metadata files

### DIFF
--- a/app/utils.py
+++ b/app/utils.py
@@ -125,6 +125,10 @@ def allowed_file(filename):
 
 def get_supported_content_extension(path):
     name = os.path.basename(str(path or ""))
+    # Ignore hidden files early
+    # Mac AppleDouble files (._) have matching extensions
+    if name.startswith("."):
+        return None
     lowered = name.lower()
     if not lowered:
         return None


### PR DESCRIPTION
#### Description
macOS AppleDouble metadata files (`._*`) can get created on external media (like Switch SD cards or game backup drives). Since they share the same extension as their source files, they accidentally match the extension filter, polluting library scans and logs with parsing errors.

To solve this, we ignore any hidden files (files starting with a dot) early in the extension matching process. A generic dotfile check is more robust here than targeting `._` files specifically, as it automatically excludes other OS-generated hidden files like `.DS_Store`.

#### User-Visible Impact
* Prevents the library scanner, downloader, and watcher from scanning, processing, or logging error tracebacks for invalid macOS companion/metadata files (e.g., `._game.nsp`).
* Keeps server logs cleaner during library scans.

#### Configuration & Migration Implications
* No configuration changes or database migrations are needed.

#### Testing & Verification
* **Manual Verification:** Tested that the check successfully handles standard extensions (e.g., `.nsp`, `.nsz`, `.xci`) while correctly filtering out `._` files and general dotfiles.

---
*Assisted by Antigravity.*
