### PR TITLE
feat: Add Expand/Collapse to Detail Card

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,6 +185,7 @@ The `Game info` modal uses TitleDB metadata:
 - `description`: shown as the game summary.
 - `screenshots`: displayed in a grid; click a screenshot to open it larger.
 - `DLC search`: admins can trigger a download search for related add-ons directly from the details flow.
+- `Expand/Collapse toggle`: toggles the details card width (between standard `modal-lg` and `90vw` expanded layout) to provide more screen space when browsing. This preference is saved for the duration of the browser session.
 
 AeroFoil will download the TitleDB descriptions/screenshot dataset on demand to `./data/titledb/US.en.json` (Docker path: `/app/data/titledb/US.en.json`).
 

--- a/app/static/style.css
+++ b/app/static/style.css
@@ -101,6 +101,23 @@
     overflow: hidden;
 }
 
+#detailsModal .btn-modal-size-toggle {
+    color: rgba(255, 255, 255, 0.65);
+    background: none;
+    border: none;
+    padding: 0;
+    box-shadow: none;
+    transition: color 0.15s ease-in-out, transform 0.15s ease-in-out;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+}
+
+#detailsModal .btn-modal-size-toggle:hover {
+    color: #fff;
+    transform: scale(1.15);
+}
+
 #detailsModal #detailsVersions {
     flex: 1 1 auto;
     min-height: 0;

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -244,7 +244,12 @@
         <div class="modal-content">
             <div class="modal-header">
                 <h1 class="modal-title fs-5" id="detailsModalLabel">Content details</h1>
-                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+                <div class="d-flex align-items-center">
+                    <button type="button" class="btn btn-link btn-modal-size-toggle me-3" id="detailsModalToggleSizeBtn" title="Expand details card">
+                        <i class="bi bi-arrows-angle-expand" id="detailsModalToggleSizeIcon" style="font-size: 1.1rem; line-height: 1;"></i>
+                    </button>
+                    <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+                </div>
             </div>
             <div class="modal-body">
                 <div class="mb-2">
@@ -2428,8 +2433,37 @@
         setDetailsStatus('', 'muted');
     }
 
+    function setDetailsModalSize(size) {
+        const $dialog = $('#detailsModal').find('.modal-dialog');
+        const $btn = $('#detailsModalToggleSizeBtn');
+        const $icon = $('#detailsModalToggleSizeIcon');
+
+        if (size === 'expanded') {
+            $dialog.css('max-width', '90vw');
+            $dialog.removeClass('modal-lg');
+            $icon.removeClass('bi-arrows-angle-expand').addClass('bi-arrows-angle-contract');
+            $btn.attr('title', 'Contract details card');
+            sessionStorage.setItem('detailsModalSize', 'expanded');
+        } else {
+            $dialog.css('max-width', '');
+            $dialog.addClass('modal-lg');
+            $icon.removeClass('bi-arrows-angle-contract').addClass('bi-arrows-angle-expand');
+            $btn.attr('title', 'Expand details card');
+            sessionStorage.setItem('detailsModalSize', 'small');
+        }
+    }
+
+    $(document).on('click', '#detailsModalToggleSizeBtn', function () {
+        const currentSize = sessionStorage.getItem('detailsModalSize') || 'small';
+        const newSize = currentSize === 'expanded' ? 'small' : 'expanded';
+        setDetailsModalSize(newSize);
+    });
+
     if (detailsModalEl) {
         detailsModalEl.addEventListener('show.bs.modal', event => {
+            const savedSize = sessionStorage.getItem('detailsModalSize') || 'small';
+            setDetailsModalSize(savedSize);
+
             const button = event.relatedTarget;
             const appId = button.getAttribute('data-bs-app-id');
             const appType = button.getAttribute('data-bs-app-type');


### PR DESCRIPTION
## Summary

Add the ability to expand/collapse the size of the Details Card, offering more page space when desired. The Setting is saved during the user's session.

Update README.md 'Game Info' section with an explanation of the Details Card size toggle and its session persistence 
behavior.

## Testing

Visual testing in browser and verification of session-persistence.

See Screenshots below for examples of expand/collapse icons

---

<img width="1155" height="973" alt="Aerofoil-Details_Card-Normal-Annotated" src="https://github.com/user-attachments/assets/a7abce1f-3f12-43ca-b6de-c5ba42f91310" />
<img width="1155" height="973" alt="Aerofoil-Details_Card-Expanded-Annotated" src="https://github.com/user-attachments/assets/b7557b79-bb3e-44cd-90f1-721356373d31" />

---
*Assisted by Antigravity.*
