### PR TITLE
feat: per-user ESRB age content filter

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,6 @@
 app/roms
 app/__pycache__
+app/config
 app/data
 app/downloads/__pycache__
 app/Start.bat

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ conversion-tmp
 # venv
 /bin
 /venv
+.venv
 /include
 /lib
 /lib64
@@ -13,6 +14,7 @@ conversion-tmp
 /share
 /Scripts
 /app/roms
+/games
 /ProdKeys
 
 .idea

--- a/app/app.py
+++ b/app/app.py
@@ -2601,6 +2601,22 @@ def _blocked_title_ids_for_cap(cap, block_unrated):
     return blocked
 
 
+def _allowed_title_ids_for_cap(cap):
+    """Return TitleDB-rated library title IDs at or below ``cap``.
+
+    Used for fail-closed browse filtering: titles absent from the metadata cache
+    are unrated and therefore must not be shown to capped users.
+    """
+    if cap is None:
+        return set()
+    metadata = _get_cached_titles_metadata()
+    rating_by_title_id = metadata.get('rating_by_title_id') or {}
+    return {
+        tid for tid, rating in rating_by_title_id.items()
+        if _title_allowed(cap, _coerce_rating_value(rating), block_unrated=True)
+    }
+
+
 def _effective_remote_addr():
     # Use trusted proxy config to resolve the true client IP.
     # Cache in `g` so multiple log calls per request are consistent and cheap.
@@ -6325,9 +6341,18 @@ def get_all_titles_api():
             query = query.filter(Titles.id == -1)
 
     if cap is not None:
-        blocked_ids = _blocked_title_ids_for_cap(cap, block_unrated)
-        if blocked_ids:
-            query = query.filter(Titles.title_id.notin_(blocked_ids))
+        if block_unrated:
+            # Fail closed: only explicitly rated, permitted titles are visible.
+            # This also hides titles absent from TitleDB metadata.
+            allowed_ids = _allowed_title_ids_for_cap(cap)
+            if allowed_ids:
+                query = query.filter(Titles.title_id.in_(allowed_ids))
+            else:
+                query = query.filter(Titles.id == -1)
+        else:
+            blocked_ids = _blocked_title_ids_for_cap(cap, block_unrated)
+            if blocked_ids:
+                query = query.filter(Titles.title_id.notin_(blocked_ids))
 
     use_name_sort = sort_key in ('title_asc', 'title_desc')
     if sort_key == 'newest':

--- a/app/app.py
+++ b/app/app.py
@@ -484,11 +484,12 @@ shop_root_cache_lock = threading.Lock()
 shop_root_cache = {
     'state_token': None,
     'files': None,
+    'files_enriched': None,
     'encrypted': {},
 }
 _SHOP_ROOT_ENCRYPTED_CACHE_LIMIT = 8
 _SHOP_SECTIONS_ENCRYPTED_CACHE_LIMIT = 8
-_TITLES_METADATA_CACHE_VERSION = 3
+_TITLES_METADATA_CACHE_VERSION = 4
 titles_metadata_cache_lock = threading.Lock()
 titles_metadata_cache = {
     'version': _TITLES_METADATA_CACHE_VERSION,
@@ -497,6 +498,7 @@ titles_metadata_cache = {
     'title_name_map': {},
     'genre_title_ids': {},
     'unrecognized_title_ids': set(),
+    'rating_by_title_id': {},
 }
 titles_total_cache_lock = threading.Lock()
 titles_total_cache = {}
@@ -701,6 +703,7 @@ def _invalidate_shop_root_cache():
     with shop_root_cache_lock:
         shop_root_cache['state_token'] = None
         shop_root_cache['files'] = None
+        shop_root_cache['files_enriched'] = None
         shop_root_cache['encrypted'] = {}
 
 def _get_titledb_aware_state_token():
@@ -749,35 +752,111 @@ def _store_titles_total(cache_key, total):
             for key, value in ordered:
                 titles_total_cache[key] = value
 
-def _get_cached_shop_files():
+def _build_enriched_shop_files():
+    """Build the shop file list annotated with each file's ESRB rating.
+
+    `rating` is the max known rating among the file's titles (most restrictive),
+    or None. `unrated` is True when any associated title is unrated or the file
+    is unidentified (no title). Used to apply the per-user age filter.
+    """
+    rows = (
+        db.session.query(
+            Files.id.label('file_id'),
+            Files.filename.label('filename'),
+            Files.size.label('size'),
+            Titles.title_id.label('title_id'),
+        )
+        .select_from(Files)
+        .outerjoin(app_files, app_files.c.file_id == Files.id)
+        .outerjoin(Apps, Apps.id == app_files.c.app_id)
+        .outerjoin(Titles, Titles.id == Apps.title_id)
+        .all()
+    )
+
+    files = {}
+    order = []
+    for row in rows:
+        fid = row.file_id
+        meta = files.get(fid)
+        if meta is None:
+            meta = {'filename': row.filename, 'size': int(row.size or 0), 'title_ids': set()}
+            files[fid] = meta
+            order.append(fid)
+        tid = (row.title_id or '').strip().upper()
+        if tid:
+            meta['title_ids'].add(tid)
+
+    rating_cache = {}
+    enriched = []
+    with titles.titledb_session() as titledb_loaded:
+        def _rating(tid):
+            if not titledb_loaded:
+                return None
+            if tid not in rating_cache:
+                info = titles.get_game_info(tid) or {}
+                rating_cache[tid] = _coerce_rating_value(info.get('rating'))
+            return rating_cache[tid]
+
+        for fid in order:
+            meta = files[fid]
+            tids = meta['title_ids']
+            if not tids:
+                file_rating = None
+                unrated = True
+            else:
+                ratings = [_rating(t) for t in tids]
+                unrated = any(r is None for r in ratings)
+                known = [r for r in ratings if r is not None]
+                file_rating = max(known) if known else None
+            enriched.append({
+                'url': f"/api/get_game/{fid}#{meta['filename']}",
+                'size': meta['size'],
+                'rating': file_rating,
+                'unrated': unrated,
+            })
+    return enriched
+
+
+def _enriched_file_allowed(entry, cap, block_unrated):
+    if cap is None:
+        return True
+    if entry.get('unrated') and block_unrated:
+        return False
+    rating = entry.get('rating')
+    if rating is None:
+        return True
+    return rating <= cap
+
+
+def _get_cached_shop_files(cap=None, block_unrated=True):
     state_token = get_library_cache_state_token()
     with shop_root_cache_lock:
-        if (
-            shop_root_cache.get('state_token') == state_token
-            and isinstance(shop_root_cache.get('files'), list)
-        ):
-            return shop_root_cache['files']
+        cached = shop_root_cache.get('files_enriched')
+        if shop_root_cache.get('state_token') == state_token and isinstance(cached, list):
+            enriched = cached
+        else:
+            enriched = None
 
-    rows = db.session.query(Files.id, Files.filename, Files.size).all()
-    files_payload = [
-        {
-            "url": f"/api/get_game/{row.id}#{row.filename}",
-            "size": int(row.size or 0),
-        }
-        for row in rows
+    if enriched is None:
+        enriched = _build_enriched_shop_files()
+        with shop_root_cache_lock:
+            shop_root_cache['state_token'] = state_token
+            shop_root_cache['files_enriched'] = enriched
+            shop_root_cache['encrypted'] = {}
+
+    if cap is None:
+        return [{"url": e["url"], "size": e["size"]} for e in enriched]
+    return [
+        {"url": e["url"], "size": e["size"]}
+        for e in enriched
+        if _enriched_file_allowed(e, cap, block_unrated)
     ]
 
-    with shop_root_cache_lock:
-        shop_root_cache['state_token'] = state_token
-        shop_root_cache['files'] = files_payload
-        shop_root_cache['encrypted'] = {}
-    return files_payload
-
-def _get_cached_encrypted_shop_payload(shop_payload, public_key, verified_host):
+def _get_cached_encrypted_shop_payload(shop_payload, public_key, verified_host, filter_token=None):
     state_token = get_library_cache_state_token()
     motd = str(shop_payload.get("success") or "")
     referrer = str(shop_payload.get("referrer") or verified_host or "")
-    cache_key = (state_token, motd, str(public_key or ''), referrer)
+    cache_key = (state_token, motd, str(public_key or ''), referrer, filter_token)
 
     with shop_root_cache_lock:
         encrypted_cache = shop_root_cache.setdefault('encrypted', {})
@@ -795,9 +874,41 @@ def _get_cached_encrypted_shop_payload(shop_payload, public_key, verified_host):
     return payload
 
 
-def _get_cached_encrypted_shop_sections_payload(shop_payload, public_key, cache_limit, full_catalog=False):
+def _filter_sections_payload(payload, cap, block_unrated):
+    """Return a copy of a sections payload with items above the age cap removed.
+
+    Each item carries a `rating` (base-title ESRB age, or None when unrated).
+    Applied per-request at the response edge so the global section caches stay
+    user-agnostic.
+    """
+    if cap is None or not isinstance(payload, dict):
+        return payload
+    sections = payload.get('sections')
+    if not isinstance(sections, list):
+        return payload
+
+    filtered_sections = []
+    for section in sections:
+        items = section.get('items') if isinstance(section, dict) else None
+        if not isinstance(items, list):
+            filtered_sections.append(section)
+            continue
+        kept = [
+            item for item in items
+            if _title_allowed(cap, _coerce_rating_value((item or {}).get('rating')), block_unrated)
+        ]
+        new_section = dict(section)
+        new_section['items'] = kept
+        filtered_sections.append(new_section)
+
+    new_payload = dict(payload)
+    new_payload['sections'] = filtered_sections
+    return new_payload
+
+
+def _get_cached_encrypted_shop_sections_payload(shop_payload, public_key, cache_limit, full_catalog=False, filter_token=None):
     state_token = _get_titledb_aware_state_token()
-    cache_key = (state_token, int(cache_limit), bool(full_catalog), str(public_key or ''))
+    cache_key = (state_token, int(cache_limit), bool(full_catalog), str(public_key or ''), filter_token)
 
     with shop_sections_cache_lock:
         encrypted_cache = shop_sections_cache.setdefault('encrypted', {})
@@ -815,7 +926,7 @@ def _get_cached_encrypted_shop_sections_payload(shop_payload, public_key, cache_
     return payload
 
 
-def _respond_with_shop_payload(payload, verified_host=None, cache_kind=None, cache_limit=None, full_catalog=False):
+def _respond_with_shop_payload(payload, verified_host=None, cache_kind=None, cache_limit=None, full_catalog=False, filter_token=None):
     response_payload = payload
     if verified_host is not None and not response_payload.get('referrer'):
         response_payload = dict(response_payload)
@@ -828,6 +939,7 @@ def _respond_with_shop_payload(payload, verified_host=None, cache_kind=None, cac
                 response_payload,
                 public_key=public_key,
                 verified_host=verified_host,
+                filter_token=filter_token,
             )
         elif cache_kind == 'sections':
             encrypted = _get_cached_encrypted_shop_sections_payload(
@@ -835,6 +947,7 @@ def _respond_with_shop_payload(payload, verified_host=None, cache_kind=None, cac
                 public_key=public_key,
                 cache_limit=cache_limit,
                 full_catalog=full_catalog,
+                filter_token=filter_token,
             )
         else:
             encrypted = encrypt_shop(response_payload, public_key_pem=public_key, compression_level=6)
@@ -907,6 +1020,7 @@ def _build_titles_metadata_cache():
     genre_title_ids = {}
     title_name_map = {}
     unrecognized_title_ids = set()
+    rating_by_title_id = {}
 
     with titles.titledb_session() as titledb_loaded:
         if not titledb_loaded:
@@ -915,6 +1029,7 @@ def _build_titles_metadata_cache():
                 'title_name_map': {},
                 'genre_title_ids': {},
                 'unrecognized_title_ids': set(),
+                'rating_by_title_id': {},
             }
 
         title_ids = [row.title_id for row in db.session.query(Titles.title_id).all() if row.title_id]
@@ -925,6 +1040,7 @@ def _build_titles_metadata_cache():
             info = titles.get_game_info(normalized_tid) or {}
             name = str(info.get('name') or '').strip()
             title_name_map[normalized_tid] = _normalize_library_search_text(name)
+            rating_by_title_id[normalized_tid] = _coerce_rating_value(info.get('rating'))
             if _is_titledb_unrecognized(info):
                 unrecognized_title_ids.add(normalized_tid)
             for genre in _split_genres_value(info.get('category') or ''):
@@ -939,6 +1055,7 @@ def _build_titles_metadata_cache():
         'title_name_map': title_name_map,
         'genre_title_ids': genre_title_ids,
         'unrecognized_title_ids': unrecognized_title_ids,
+        'rating_by_title_id': rating_by_title_id,
     }
 
 def _get_cached_titles_metadata():
@@ -956,6 +1073,7 @@ def _get_cached_titles_metadata():
                     for k, v in (titles_metadata_cache.get('genre_title_ids') or {}).items()
                 },
                 'unrecognized_title_ids': set(titles_metadata_cache.get('unrecognized_title_ids') or set()),
+                'rating_by_title_id': dict(titles_metadata_cache.get('rating_by_title_id') or {}),
             }
 
     fresh = _build_titles_metadata_cache()
@@ -969,6 +1087,7 @@ def _get_cached_titles_metadata():
             for k, v in (fresh.get('genre_title_ids') or {}).items()
         }
         titles_metadata_cache['unrecognized_title_ids'] = set(fresh.get('unrecognized_title_ids') or set())
+        titles_metadata_cache['rating_by_title_id'] = dict(fresh.get('rating_by_title_id') or {})
     return fresh
 
 def _get_cached_library_genres():
@@ -1268,6 +1387,8 @@ def _build_shop_sections_payload(limit, full_catalog=False):
                 title_name = title_id or name
                 category = ''
             icon_url = f'/api/shop/icon/{title_id}' if title_id else ((app_info or {}).get('iconUrl') or '')
+            # Base-title rating governs the whole title (updates/DLC inherit it).
+            rating = _coerce_rating_value((base_info or {}).get('rating'))
 
             return {
                 'name': name,
@@ -1277,6 +1398,7 @@ def _build_shop_sections_payload(limit, full_catalog=False):
                 'app_version': row.app_version,
                 'app_type': row.app_type,
                 'category': category,
+                'rating': rating,
                 'icon_url': icon_url,
                 'iconUrl': icon_url,
                 'url': f"/api/get_game/{int(row.file_id)}#{row.filename}",
@@ -2336,6 +2458,149 @@ def _get_request_user():
     return None
 
 
+# --- ESRB / age content filter ---------------------------------------------
+
+def _content_filter_block_unrated():
+    try:
+        settings = load_settings()
+        return bool((settings or {}).get('content_filter', {}).get('block_unrated', True))
+    except Exception:
+        return True
+
+
+def _coerce_rating_value(rating):
+    """Coerce a rating to a non-negative int age, or None if unknown/unrated."""
+    if rating is None:
+        return None
+    try:
+        value = int(rating)
+    except (TypeError, ValueError):
+        return None
+    return value if value >= 0 else None
+
+
+def _title_rating(title_id):
+    """Return the ESRB minimum-age int for a title_id, or None if unknown.
+
+    Opens its own TitleDB session; intended for single-title checks (e.g. the
+    download gate). List builders should reuse an open session instead.
+    """
+    tid = str(title_id or '').strip().upper()
+    if not tid:
+        return None
+    try:
+        with titles.titledb_session() as titledb_loaded:
+            if not titledb_loaded:
+                return None
+            info = titles.get_game_info(tid) or {}
+    except Exception:
+        return None
+    return _coerce_rating_value(info.get('rating'))
+
+
+def _title_allowed(cap, rating, block_unrated):
+    """Whether a title is visible/downloadable under an age cap.
+
+    cap is None        -> unrestricted (always allowed)
+    rating is None      -> allowed only when not block_unrated (fail-closed)
+    otherwise           -> allowed when rating <= cap
+    """
+    if cap is None:
+        return True
+    if rating is None:
+        return not bool(block_unrated)
+    try:
+        return int(rating) <= int(cap)
+    except (TypeError, ValueError):
+        return not bool(block_unrated)
+
+
+def _user_rating_cap(username=None):
+    """Resolve (cap, block_unrated) for the requesting (or named) user.
+
+    cap is the user's max_rating int, or None when unrestricted/unknown user.
+    """
+    block_unrated = _content_filter_block_unrated()
+    user = None
+    try:
+        if username is None:
+            try:
+                if current_user.is_authenticated:
+                    user = current_user
+            except Exception:
+                user = None
+            if user is None:
+                username = _get_request_user()
+        if user is None and username:
+            user = User.query.filter_by(user=username).first()
+        cap = getattr(user, 'max_rating', None) if user is not None else None
+    except Exception:
+        cap = None
+    try:
+        cap = int(cap) if cap is not None else None
+    except (TypeError, ValueError):
+        cap = None
+    return cap, block_unrated
+
+
+def _file_title_ids(file_id):
+    """All distinct title_ids associated with a file (multicontent-safe)."""
+    rows = (
+        db.session.query(Titles.title_id)
+        .select_from(Files)
+        .outerjoin(app_files, app_files.c.file_id == Files.id)
+        .outerjoin(Apps, Apps.id == app_files.c.app_id)
+        .outerjoin(Titles, Titles.id == Apps.title_id)
+        .filter(Files.id == file_id)
+        .all()
+    )
+    seen = []
+    for row in rows:
+        tid = (row[0] or '').strip().upper()
+        if tid and tid not in seen:
+            seen.append(tid)
+    return seen
+
+
+def _file_blocked_by_cap(file_id, cap, block_unrated):
+    """True if a file must be hidden/blocked for the given age cap.
+
+    Gates on the most restrictive associated title (fail-closed): an unidentified
+    file, or any title that is unrated/over-cap, blocks the whole file.
+    """
+    if cap is None:
+        return False
+    title_ids = _file_title_ids(file_id)
+    if not title_ids:
+        return bool(block_unrated)
+    with titles.titledb_session() as titledb_loaded:
+        for tid in title_ids:
+            rating = None
+            if titledb_loaded:
+                info = titles.get_game_info(tid) or {}
+                rating = _coerce_rating_value(info.get('rating'))
+            if not _title_allowed(cap, rating, block_unrated):
+                return True
+    return False
+
+
+def _blocked_title_ids_for_cap(cap, block_unrated):
+    """Set of library title_ids that must be hidden for the given age cap.
+
+    Backed by the per-state-token titles metadata cache (rating_by_title_id),
+    so this is cheap to call per request.
+    """
+    if cap is None:
+        return set()
+    metadata = _get_cached_titles_metadata()
+    rating_by_title_id = metadata.get('rating_by_title_id') or {}
+    blocked = set()
+    for tid, rating in rating_by_title_id.items():
+        if not _title_allowed(cap, _coerce_rating_value(rating), block_unrated):
+            blocked.add(tid)
+    return blocked
+
+
 def _effective_remote_addr():
     # Use trusted proxy config to resolve the true client IP.
     # Cache in `g` so multiple log calls per request are consistent and cheap.
@@ -3381,10 +3646,11 @@ def index():
                 motd_text = _render_motd_template(app_settings['shop']['motd'])
         except Exception:
             motd_text = ''
+        cap, block_unrated = _user_rating_cap()
         shop = {
             "success": motd_text
         }
-        shop["files"] = _get_cached_shop_files()
+        shop["files"] = _get_cached_shop_files(cap=cap, block_unrated=block_unrated)
 
         if _is_cyberfoil_request():
             _log_access(
@@ -3395,7 +3661,12 @@ def index():
                 duration_ms=int((time.time() - start_ts) * 1000),
             )
 
-        return _respond_with_shop_payload(shop, verified_host=request.verified_host, cache_kind='root')
+        return _respond_with_shop_payload(
+            shop,
+            verified_host=request.verified_host,
+            cache_kind='root',
+            filter_token=(cap, block_unrated),
+        )
     
     if is_shop_client or (tinfoil_only_mode and not prefers_html):
         logger.info(
@@ -4170,6 +4441,18 @@ def get_settings_api():
     settings.setdefault('downloads', {})
     settings['downloads']['client_capabilities'] = get_supported_download_clients()
     return jsonify(settings)
+
+@app.post('/api/settings/content-filter')
+@access_required('admin')
+def set_content_filter_settings_api():
+    data = request.json or {}
+    block_unrated = bool(data.get('block_unrated'))
+    set_content_filter_settings({'block_unrated': block_unrated})
+    reload_conf()
+    # Encrypted shop payloads vary by filter; drop caches so changes apply now.
+    _invalidate_shop_root_cache()
+    return jsonify({'success': True, 'errors': []})
+
 
 @app.post('/api/settings/titles')
 @access_required('admin')
@@ -5795,6 +6078,8 @@ def get_all_titles_api():
     titles_metadata = None
     search_normalized = ''
     allowed_types = set()
+    # Per-user ESRB age filter for the web browse view.
+    cap, block_unrated = _user_rating_cap()
 
     size_subquery = (
         db.session.query(
@@ -6039,6 +6324,11 @@ def get_all_titles_api():
         else:
             query = query.filter(Titles.id == -1)
 
+    if cap is not None:
+        blocked_ids = _blocked_title_ids_for_cap(cap, block_unrated)
+        if blocked_ids:
+            query = query.filter(Titles.title_id.notin_(blocked_ids))
+
     use_name_sort = sort_key in ('title_asc', 'title_desc')
     if sort_key == 'newest':
         query = query.order_by(Titles.id.desc(), Apps.id.desc())
@@ -6056,6 +6346,7 @@ def get_all_titles_api():
         str(completion or ''),
         str(genre or '').lower(),
         'unrecognized' if recognized == 'unrecognized' else ('recognized' if recognized == 'recognized' else ''),
+        ('cap', cap, bool(block_unrated)) if cap is not None else 'nocap',
     )
     total = _get_cached_titles_total(count_cache_key)
     if total is None:
@@ -6212,6 +6503,15 @@ def get_all_titles_api():
         games.append(game)
 
     newest, recommended = _get_discovery_sections(limit=12)
+    if cap is not None:
+        newest = [
+            item for item in newest
+            if _title_allowed(cap, _coerce_rating_value((item or {}).get('rating')), block_unrated)
+        ]
+        recommended = [
+            item for item in recommended
+            if _title_allowed(cap, _coerce_rating_value((item or {}).get('rating')), block_unrated)
+        ]
 
     if lite:
         def _lite(entry):
@@ -6601,6 +6901,15 @@ def serve_game(id):
     if not file_row:
         return Response(status=404)
 
+    # Per-user ESRB age filter: block downloads above the requester's cap.
+    cap, block_unrated = _user_rating_cap(username)
+    if cap is not None and _file_blocked_by_cap(id, cap, block_unrated):
+        logger.info(
+            "Blocked download of file id %s for user %r: exceeds age cap %s.",
+            id, username, cap,
+        )
+        return Response(status=403)
+
     try:
         queue_file_download_increment(id)
     except Exception as e:
@@ -6792,11 +7101,17 @@ def shop_sections_api():
             duration_ms=int((time.time() - start_ts) * 1000),
         )
 
+    # Per-user ESRB age filter: applied at the response edge so the global
+    # section caches above stay user-agnostic.
+    cap, block_unrated = _user_rating_cap()
+    response_payload = _filter_sections_payload(payload, cap, block_unrated)
+
     return _respond_with_shop_payload(
-        payload,
+        response_payload,
         cache_kind='sections',
         cache_limit=cache_limit,
         full_catalog=is_cyberfoil,
+        filter_token=(cap, block_unrated),
     )
 
 

--- a/app/auth.py
+++ b/app/auth.py
@@ -699,23 +699,41 @@ auth_blueprint = Blueprint('auth', __name__)
 login_manager = LoginManager()
 login_manager.login_view = 'auth.login'
 
-def create_or_update_user(username, password, admin_access=False, shop_access=False, backup_access=False):
+def normalize_max_rating(value):
+    """Coerce an incoming max_rating to a valid ESRB age int, or None.
+
+    None / blank means unrestricted. Unknown values fall back to None.
+    """
+    if value is None:
+        return None
+    if isinstance(value, str) and not value.strip():
+        return None
+    try:
+        rating = int(value)
+    except (TypeError, ValueError):
+        return None
+    return rating if rating in ESRB_VALID_AGES else None
+
+
+def create_or_update_user(username, password, admin_access=False, shop_access=False, backup_access=False, max_rating=None):
     """
     Create a new user or update an existing user with the given credentials and access rights.
     """
+    max_rating = normalize_max_rating(max_rating)
     user = User.query.filter_by(user=username).first()
     if user:
         logger.info(f'Updating existing user {username}')
         user.admin_access = admin_access
         user.shop_access = shop_access
         user.backup_access = backup_access
+        user.max_rating = max_rating
         if getattr(user, 'frozen', False) and admin_access:
             user.frozen = False
             user.frozen_message = None
         user.password = generate_password_hash(password, method='scrypt')
     else:
         logger.info(f'Creating new user {username}')
-        new_user = User(user=username, password=generate_password_hash(password, method='scrypt'), admin_access=admin_access, shop_access=shop_access, backup_access=backup_access)
+        new_user = User(user=username, password=generate_password_hash(password, method='scrypt'), admin_access=admin_access, shop_access=shop_access, backup_access=backup_access, max_rating=max_rating)
         db.session.add(new_user)
     db.session.commit()
     _invalidate_admin_exists_cache()
@@ -850,6 +868,7 @@ def get_users():
             User.backup_access,
             User.frozen,
             User.frozen_message,
+            User.max_rating,
             User.client_uid,
             User.last_login_at,
             User.last_login_ip,
@@ -1049,6 +1068,7 @@ def update_user():
     admin_access = data.get('admin_access')
     shop_access = data.get('shop_access')
     backup_access = data.get('backup_access')
+    max_rating = normalize_max_rating(data.get('max_rating'))
 
     if not user_id:
         errors.append('Missing user id.')
@@ -1081,6 +1101,7 @@ def update_user():
         user.admin_access = admin_access
         user.shop_access = shop_access
         user.backup_access = backup_access
+        user.max_rating = max_rating
         if getattr(user, 'frozen', False) and admin_access:
             user.frozen = False
             user.frozen_message = None
@@ -1151,6 +1172,7 @@ def signup_post():
     username = data['user']
     password = data['password']
     admin_access = data['admin_access']
+    max_rating = normalize_max_rating(data.get('max_rating'))
     if admin_access:
         shop_access = True
         backup_access = True
@@ -1176,7 +1198,7 @@ def signup_post():
         return jsonify(resp)
 
     # create a new user with the form data. Hash the password so the plaintext version isn't saved.
-    create_or_update_user(username, password, admin_access, shop_access, backup_access)
+    create_or_update_user(username, password, admin_access, shop_access, backup_access, max_rating=max_rating)
     
     logger.info(f'Successfully created user {username}.')
 

--- a/app/constants.py
+++ b/app/constants.py
@@ -161,6 +161,12 @@ DEFAULT_SETTINGS = {
         "clientCertKey": "-----BEGIN PRIVATE KEY-----",
         "host": "",
         "hauth": "",
+    },
+    "content_filter": {
+        # When a user has an age cap (max_rating) set, also hide/block titles
+        # that have no known rating (homebrew, unidentified files, or titles
+        # missing from TitleDB). True = fail-closed (safest for child accounts).
+        "block_unrated": True,
     }
 }
 
@@ -242,3 +248,21 @@ APP_TYPE_MAP = {
     129: APP_TYPE_UPD,
     130: APP_TYPE_DLC,
 }
+
+# ESRB content rating scale. The numeric "age" matches TitleDB's `rating` field
+# (the eShop minimum-age recommendation, e.g. Breath of the Wild = 10 = E10+).
+# Filtering compares numerically, so it also works for PEGI-region TitleDB data;
+# the labels assume the US (ESRB) region.
+ESRB_RATINGS = [
+    {"code": "E", "age": 0, "label": "Everyone"},
+    {"code": "E10", "age": 10, "label": "Everyone 10+"},
+    {"code": "T", "age": 13, "label": "Teen"},
+    {"code": "M", "age": 17, "label": "Mature 17+"},
+    {"code": "AO", "age": 18, "label": "Adults Only 18+"},
+]
+ESRB_AGE_BY_CODE = {item["code"]: item["age"] for item in ESRB_RATINGS}
+ESRB_VALID_AGES = [item["age"] for item in ESRB_RATINGS]
+
+# Bump to force a one-time rebuild of the titles SQLite index when its on-disk
+# schema changes (the `rating` column was added in this version).
+TITLES_INDEX_SCHEMA_VERSION = 'rating-v1'

--- a/app/db.py
+++ b/app/db.py
@@ -179,6 +179,8 @@ class User(UserMixin, db.Model):
     backup_access = db.Column(db.Boolean)
     frozen = db.Column(db.Boolean, default=False)
     frozen_message = db.Column(db.String)
+    # ESRB age cap (TitleDB minimum-age int). NULL = unrestricted.
+    max_rating = db.Column(db.Integer)
     client_uid = db.Column(db.String)
     last_login_at = db.Column(db.DateTime)
     last_login_ip = db.Column(db.String)
@@ -654,6 +656,7 @@ def ensure_user_client_schema():
         ('last_login_ip', 'TEXT'),
         ('last_login_country', 'TEXT'),
         ('last_login_country_code', 'TEXT'),
+        ('max_rating', 'INTEGER'),
     ]
 
     try:

--- a/app/settings.py
+++ b/app/settings.py
@@ -556,6 +556,18 @@ def _normalize_shop_settings(raw_shop):
     return merged
 
 
+def _normalize_content_filter_settings(raw_content_filter):
+    defaults = DEFAULT_SETTINGS.get('content_filter', {}) or {}
+    merged = defaults.copy()
+    if isinstance(raw_content_filter, dict):
+        merged.update(raw_content_filter)
+    merged['block_unrated'] = _coerce_bool(
+        merged.get('block_unrated'),
+        default=defaults.get('block_unrated', True),
+    )
+    return merged
+
+
 def _validate_shop_public_key(public_key_pem):
     key_text = str(public_key_pem or '').strip()
     if not key_text:
@@ -701,6 +713,7 @@ def load_settings(force_reload=False):
         _merge_section('shop')
         _merge_section('titles')
         _merge_section('library')
+        _merge_section('content_filter')
 
         env_trust = _read_env_bool('AEROFOIL_TRUST_PROXY_HEADERS')
         if env_trust is None:
@@ -734,6 +747,7 @@ def load_settings(force_reload=False):
         settings['downloads'] = _normalize_download_settings(settings.get('downloads'))
         settings['titles'] = _normalize_titles_settings(settings.get('titles'))
         settings['shop'] = _normalize_shop_settings(settings.get('shop'))
+        settings['content_filter'] = _normalize_content_filter_settings(settings.get('content_filter'))
         settings['library']['conversion_staging_dir'] = _normalize_conversion_staging_dir(
             settings['library'].get('conversion_staging_dir')
         )
@@ -937,6 +951,16 @@ def set_shop_settings(data):
     with open(CONFIG_FILE, 'w') as yaml_file:
         yaml.dump(settings, yaml_file)
     _invalidate_settings_cache()
+
+def set_content_filter_settings(data):
+    settings = load_settings(force_reload=True)
+    settings.setdefault('content_filter', {})
+    settings['content_filter'].update(data or {})
+    settings['content_filter'] = _normalize_content_filter_settings(settings.get('content_filter'))
+    with open(CONFIG_FILE, 'w') as yaml_file:
+        yaml.dump(settings, yaml_file)
+    _invalidate_settings_cache()
+
 
 def set_download_settings(data):
     settings = load_settings(force_reload=True)

--- a/app/templates/settings.html
+++ b/app/templates/settings.html
@@ -719,6 +719,15 @@
                                     Prioritize throughput by skipping per-chunk transfer tracking. Activity live byte counters and exact transfer byte accounting may be less precise.
                                 </div>
                             </div>
+                            <div class="form-check">
+                                <input type="checkbox" class="form-check-input" id="blockUnratedCheck"
+                                    aria-describedby="blockUnratedCheckHelp" onChange="submitContentFilterSettings()">
+                                <label class="form-check-label" for="blockUnratedCheck">Hide unrated titles from age-capped users</label>
+                                <div id="blockUnratedCheckHelp" class="form-text">
+                                    When a user has a max rating set, also hide titles with no known ESRB rating
+                                    (homebrew, unidentified files, or titles missing from TitleDB). Recommended for child accounts.
+                                </div>
+                            </div>
                         </div>
                     </div>
                 </div>
@@ -1911,6 +1920,22 @@
         });
     }
 
+    function submitContentFilterSettings() {
+        const data = {
+            block_unrated: getCheckboxStatus("blockUnratedCheck"),
+        };
+        $.ajax({
+            url: "/api/settings/content-filter",
+            type: 'POST',
+            data: JSON.stringify(data),
+            contentType: "application/json",
+            error: function (xhr) {
+                const result = xhr && xhr.responseJSON ? xhr.responseJSON : {};
+                renderSettingsErrors(result['errors']);
+            }
+        });
+    }
+
     function splitTerms(value) {
         if (!value) {
             return [];
@@ -2990,6 +3015,8 @@
             $("#encryptShopCheck").prop("checked", shopSettings['encrypt']);
             $("#tinfoilOnlyModeCheck").prop("checked", !!shopSettings['tinfoil_only_mode']);
             $("#fastTransferModeCheck").prop("checked", !!shopSettings['fast_transfer_mode']);
+            const contentFilterSettings = result['content_filter'] || {};
+            $("#blockUnratedCheck").prop("checked", contentFilterSettings['block_unrated'] !== false);
             syncTinfoilOnlyModeControls();
             setInputVal("shopPublicKeyInput", shopSettings['public_key'] || '');
             securitySettings = result['security'] || {};

--- a/app/templates/users.html
+++ b/app/templates/users.html
@@ -80,6 +80,18 @@
                                     </div>
                                 </div>
                             </div>
+                            <div class="col-md-4">
+                                <label for="selectNewUserMaxRating" class="form-label">Max rating</label>
+                                <select class="form-select" id="selectNewUserMaxRating">
+                                    <option value="" selected>No limit</option>
+                                    <option value="0">Everyone (E)</option>
+                                    <option value="10">Everyone 10+ (E10+)</option>
+                                    <option value="13">Teen (T)</option>
+                                    <option value="17">Mature 17+ (M)</option>
+                                    <option value="18">Adults Only 18+ (AO)</option>
+                                </select>
+                                <div class="form-text">Hide titles above this ESRB rating from this user's shop.</div>
+                            </div>
                             <div class="col-12">
                                 <button type="button" class="btn btn-primary" onClick='submitNewUser()'>Create user</button>
                             </div>
@@ -162,6 +174,18 @@
                                             <label class="form-check-label" for="checkboxEditUserAdminAccess">Admin</label>
                                         </div>
                                     </div>
+                                </div>
+                                <div class="mb-3">
+                                    <label for="editUserMaxRatingSelect" class="form-label">Max rating</label>
+                                    <select class="form-select" id="editUserMaxRatingSelect">
+                                        <option value="">No limit</option>
+                                        <option value="0">Everyone (E)</option>
+                                        <option value="10">Everyone 10+ (E10+)</option>
+                                        <option value="13">Teen (T)</option>
+                                        <option value="17">Mature 17+ (M)</option>
+                                        <option value="18">Adults Only 18+ (AO)</option>
+                                    </select>
+                                    <div class="form-text">Hide titles above this ESRB rating from this user's shop.</div>
                                 </div>
                             </div>
                             <div class="modal-footer">
@@ -445,6 +469,14 @@
         return (user['admin_access'] ? 4 : 0) + (user['shop_access'] ? 2 : 0) + (user['backup_access'] ? 1 : 0);
     }
 
+    const RATING_LABELS = { '0': 'E', '10': 'E10+', '13': 'T', '17': 'M', '18': 'AO' };
+    function _ratingLabel(value) {
+        if (value === null || value === undefined || value === '') {
+            return '';
+        }
+        return RATING_LABELS[String(value)] || ('age ' + value);
+    }
+
     function _filteredUsers() {
         const q = (getInputVal('userSearchInput') || '').trim().toLowerCase();
         let users = allUsers || [];
@@ -653,6 +685,10 @@
             if (!badges) {
                 badges = '<span class="badge text-bg-secondary">None</span>';
             }
+            const maxRatingLabel = _ratingLabel(user['max_rating']);
+            if (maxRatingLabel) {
+                badges += '<span class="badge text-bg-dark ms-1">≤ ' + _escapeHtml(maxRatingLabel) + '</span>';
+            }
 
             const username = _escapeHtml(user['user']);
             const uidValue = _escapeHtml(user['client_uid'] || '-');
@@ -678,7 +714,8 @@
                 + '<div class="user-actions">'
                 + '<button type="button" class="btn btn-outline-info btn-sm" data-bs-toggle="modal" data-bs-target="#editUserModal" data-bs-title="Modify user" data-bs-placement="top"'
                 + ' data-bs-id="' + user['id'] + '" data-bs-user="' + _escapeHtml(user['user']) + '"'
-                + ' data-bs-admin="' + user['admin_access'] + '" data-bs-shop="' + user['shop_access'] + '" data-bs-backup="' + user['backup_access'] + '">'
+                + ' data-bs-admin="' + user['admin_access'] + '" data-bs-shop="' + user['shop_access'] + '" data-bs-backup="' + user['backup_access'] + '"'
+                + ' data-bs-max-rating="' + (user['max_rating'] === null || user['max_rating'] === undefined ? '' : user['max_rating']) + '">'
                 + '<i class="bi bi-pencil-square"></i></button>'
                 + '<button type="button" class="btn btn-outline-secondary btn-sm" data-bs-toggle="modal" data-bs-target="#userHistoryModal" data-bs-title="View history" data-bs-placement="top"'
                 + ' data-bs-id="' + user['id'] + '" data-bs-user="' + _escapeHtml(user['user']) + '">'
@@ -865,12 +902,16 @@
             return;
         }
 
+        const maxRatingRaw = getInputVal("selectNewUserMaxRating");
+        const max_rating = (maxRatingRaw === '' || maxRatingRaw === null || maxRatingRaw === undefined) ? null : parseInt(maxRatingRaw, 10);
+
         data = {
             user: user,
             password: password,
             shop_access: shop_access,
             backup_access: backup_access,
             admin_access: admin_access,
+            max_rating: max_rating,
         }
 
         $.ajax({
@@ -886,6 +927,7 @@
                     }
                     setInputVal("inputNewUser", "")
                     setInputVal("inputNewUserPassword", "")
+                    setInputVal("selectNewUserMaxRating", "")
                     fillUserTable();
                 }
             }
@@ -903,8 +945,10 @@
             const adminAccess = button.getAttribute('data-bs-admin') === 'true'
             const shopAccess = button.getAttribute('data-bs-shop') === 'true'
             const backupAccess = button.getAttribute('data-bs-backup') === 'true'
+            const maxRating = button.getAttribute('data-bs-max-rating')
 
             setInputVal("editUserNameInput", editOriginalUser)
+            setInputVal("editUserMaxRatingSelect", (maxRating === null || maxRating === undefined) ? '' : maxRating)
             $('#editUserModalLabel').text('Modify user');
             $('#submitModifyUserBtn').text('Save');
             $("#checkboxEditUserAdminAccess").prop("checked", adminAccess)
@@ -954,12 +998,16 @@
             return;
         }
 
+        const maxRatingRaw = getInputVal("editUserMaxRatingSelect");
+        const max_rating = (maxRatingRaw === '' || maxRatingRaw === null || maxRatingRaw === undefined) ? null : parseInt(maxRatingRaw, 10);
+
         data = {
             user_id: editUserId,
             user: user,
             shop_access: shop_access,
             backup_access: backup_access,
             admin_access: admin_access,
+            max_rating: max_rating,
         }
 
         $.ajax({

--- a/app/titles.py
+++ b/app/titles.py
@@ -204,7 +204,9 @@ def _versions_source_signature(path):
     return f"{int(stat.st_size)}:{int(mtime_ns)}"
 
 def _titles_sources_signature(paths):
-    parts = []
+    # Prefix with the index schema version so a column change forces a one-time
+    # rebuild even when the underlying source files are unchanged.
+    parts = [f"schema:{TITLES_INDEX_SCHEMA_VERSION}"]
     for path in (paths or []):
         parts.append(f"{os.path.basename(path)}:{_versions_source_signature(path)}")
     return "|".join(parts)
@@ -244,6 +246,20 @@ def _release_process_memory():
             _malloc_trim(0)
         except Exception:
             pass
+
+def _coerce_rating(value):
+    """Coerce a TitleDB `rating` value to an int age, or None if unknown.
+
+    TitleDB stores the eShop minimum-age recommendation as an integer. Negative
+    sentinels (e.g. -1) and blanks are treated as "unrated".
+    """
+    if value is None:
+        return None
+    try:
+        rating = int(value)
+    except (TypeError, ValueError):
+        return None
+    return rating if rating >= 0 else None
 
 def _normalize_title_search_text(value):
     text = str(value or '')
@@ -529,6 +545,7 @@ def _ensure_titles_index_from_sources(source_files, index_file, log_label='title
                 "category TEXT, "
                 "nsu_id TEXT, "
                 "description TEXT, "
+                "rating INTEGER, "
                 "search_hay TEXT, "
                 "sort_order INTEGER NOT NULL)"
             )
@@ -567,6 +584,7 @@ def _ensure_titles_index_from_sources(source_files, index_file, log_label='title
                 "category TEXT, "
                 "nsu_id TEXT, "
                 "description TEXT, "
+                "rating INTEGER, "
                 "search_hay TEXT, "
                 "sort_order INTEGER NOT NULL)"
             )
@@ -595,6 +613,7 @@ def _ensure_titles_index_from_sources(source_files, index_file, log_label='title
                     nsu_id_raw = item.get('nsuId')
                     nsu_id = None if nsu_id_raw is None else str(nsu_id_raw)
                     description = str(item.get('description') or '').strip() or None
+                    rating = _coerce_rating(item.get('rating'))
                     search_hay = _normalize_title_search_text(f"{title_id} {name}")
                     batch.append((
                         title_id,
@@ -604,22 +623,23 @@ def _ensure_titles_index_from_sources(source_files, index_file, log_label='title
                         category,
                         nsu_id,
                         description,
+                        rating,
                         search_hay,
                         int(order),
                     ))
                     if len(batch) >= batch_size:
                         conn.executemany(
                             "INSERT OR REPLACE INTO titles "
-                            "(title_id, name, banner_url, icon_url, category, nsu_id, description, search_hay, sort_order) "
-                            "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                            "(title_id, name, banner_url, icon_url, category, nsu_id, description, rating, search_hay, sort_order) "
+                            "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
                             batch,
                         )
                         batch.clear()
             if batch:
                 conn.executemany(
                     "INSERT OR REPLACE INTO titles "
-                    "(title_id, name, banner_url, icon_url, category, nsu_id, description, search_hay, sort_order) "
-                    "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                    "(title_id, name, banner_url, icon_url, category, nsu_id, description, rating, search_hay, sort_order) "
+                    "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
                     batch,
                 )
 
@@ -1364,7 +1384,7 @@ def _get_title_info_from_index_file(title_key, index_file, cache_store, cache_lo
         conn = _open_versions_index_db(index_file)
         try:
             row = conn.execute(
-                "SELECT name, banner_url, icon_url, title_id, category, nsu_id, description "
+                "SELECT name, banner_url, icon_url, title_id, category, nsu_id, description, rating "
                 "FROM titles WHERE title_id = ? LIMIT 1",
                 (title_key,),
             ).fetchone()
@@ -1385,6 +1405,7 @@ def _get_title_info_from_index_file(title_key, index_file, cache_store, cache_lo
         'category': row[4] or '',
         'nsuId': row[5],
         'description': row[6],
+        'rating': row[7],
     }
     with cache_lock:
         cache_store[title_key] = info
@@ -1415,7 +1436,7 @@ def _merge_preferred_title_info(base_info, preferred_info):
     merged = dict(base_info or {})
     if not isinstance(preferred_info, dict):
         return merged
-    for key in ('name', 'bannerUrl', 'iconUrl', 'id', 'category', 'nsuId', 'description'):
+    for key in ('name', 'bannerUrl', 'iconUrl', 'id', 'category', 'nsuId', 'description', 'rating'):
         value = preferred_info.get(key)
         if value is None:
             continue
@@ -1715,6 +1736,7 @@ def get_game_info(title_id):
             'category': '',
             'nsuId': None,
             'description': None,
+            'rating': None,
             'screenshots': [],
         })
 
@@ -1782,6 +1804,7 @@ def get_game_info(title_id):
             'category': merged_title_info.get('category') or '',
             'nsuId': merged_title_info.get('nsuId'),
             'description': description,
+            'rating': resolved_title_info.get('rating'),
             'screenshots': screenshots,
         })
     except Exception:
@@ -1811,6 +1834,7 @@ def get_game_info(title_id):
             'category': '',
             'nsuId': None,
             'description': None,
+            'rating': None,
             'screenshots': [],
         })
 

--- a/tests/test_esrb_filter.py
+++ b/tests/test_esrb_filter.py
@@ -1,0 +1,155 @@
+import unittest
+from unittest.mock import patch
+
+
+_IMPORT_ERROR = None
+appmod = None
+normalize_max_rating = None
+try:
+    from app import app as appmod
+    from app.auth import normalize_max_rating
+except ModuleNotFoundError as exc:
+    _IMPORT_ERROR = exc
+
+
+class EsrbFilterTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        if _IMPORT_ERROR is not None:
+            raise unittest.SkipTest(f"Missing dependency for ESRB filter tests: {_IMPORT_ERROR}")
+
+    # --- _coerce_rating_value --------------------------------------------
+    def test_coerce_rating_value(self):
+        self.assertIsNone(appmod._coerce_rating_value(None))
+        self.assertIsNone(appmod._coerce_rating_value(''))
+        self.assertIsNone(appmod._coerce_rating_value('abc'))
+        self.assertIsNone(appmod._coerce_rating_value(-1))
+        self.assertEqual(appmod._coerce_rating_value(0), 0)
+        self.assertEqual(appmod._coerce_rating_value('10'), 10)
+        self.assertEqual(appmod._coerce_rating_value(17), 17)
+
+    # --- _title_allowed truth table --------------------------------------
+    def test_no_cap_allows_everything(self):
+        self.assertTrue(appmod._title_allowed(None, 18, True))
+        self.assertTrue(appmod._title_allowed(None, None, True))
+
+    def test_rating_at_or_below_cap_allowed(self):
+        self.assertTrue(appmod._title_allowed(13, 0, True))
+        self.assertTrue(appmod._title_allowed(13, 13, True))  # boundary
+        self.assertFalse(appmod._title_allowed(13, 17, True))
+
+    def test_unrated_fail_closed_vs_open(self):
+        # block_unrated=True -> hidden; block_unrated=False -> shown.
+        self.assertFalse(appmod._title_allowed(13, None, True))
+        self.assertTrue(appmod._title_allowed(13, None, False))
+
+    # --- _enriched_file_allowed ------------------------------------------
+    def test_enriched_file_allowed(self):
+        below = {'rating': 10, 'unrated': False}
+        above = {'rating': 17, 'unrated': False}
+        unrated = {'rating': None, 'unrated': True}
+
+        self.assertTrue(appmod._enriched_file_allowed(below, None, True))   # no cap
+        self.assertTrue(appmod._enriched_file_allowed(below, 13, True))
+        self.assertFalse(appmod._enriched_file_allowed(above, 13, True))
+        self.assertFalse(appmod._enriched_file_allowed(unrated, 13, True))
+        self.assertTrue(appmod._enriched_file_allowed(unrated, 13, False))
+
+    # --- _filter_sections_payload ----------------------------------------
+    def _sample_payload(self):
+        return {
+            'sections': [
+                {'id': 'all', 'title': 'All', 'items': [
+                    {'title_id': 'A', 'rating': 0},
+                    {'title_id': 'B', 'rating': 17},
+                    {'title_id': 'C', 'rating': None},
+                ]},
+            ]
+        }
+
+    def test_filter_sections_no_cap_returns_same_object(self):
+        payload = self._sample_payload()
+        self.assertIs(appmod._filter_sections_payload(payload, None, True), payload)
+
+    def test_filter_sections_fail_closed(self):
+        payload = self._sample_payload()
+        out = appmod._filter_sections_payload(payload, 13, True)
+        kept = [item['title_id'] for item in out['sections'][0]['items']]
+        self.assertEqual(kept, ['A'])
+        # Original payload is not mutated.
+        self.assertEqual(len(payload['sections'][0]['items']), 3)
+
+    def test_filter_sections_fail_open_keeps_unrated(self):
+        payload = self._sample_payload()
+        out = appmod._filter_sections_payload(payload, 13, False)
+        kept = [item['title_id'] for item in out['sections'][0]['items']]
+        self.assertEqual(kept, ['A', 'C'])
+
+    # --- _file_blocked_by_cap (multicontent fail-closed) -----------------
+    def test_file_blocked_no_cap(self):
+        self.assertFalse(appmod._file_blocked_by_cap(1, None, True))
+
+    def test_file_blocked_unidentified_file(self):
+        with patch.object(appmod, '_file_title_ids', return_value=[]):
+            self.assertTrue(appmod._file_blocked_by_cap(1, 13, True))
+            self.assertFalse(appmod._file_blocked_by_cap(1, 13, False))
+
+    def test_file_blocked_by_most_restrictive_title(self):
+        ratings = {'AAAA': 0, 'BBBB': 17}
+
+        def fake_get_game_info(tid):
+            return {'rating': ratings.get(tid)}
+
+        with patch.object(appmod, '_file_title_ids', return_value=['AAAA', 'BBBB']), \
+             patch.object(appmod.titles, 'titledb_session') as session_mock, \
+             patch.object(appmod.titles, 'get_game_info', side_effect=fake_get_game_info):
+            session_mock.return_value.__enter__.return_value = True
+            session_mock.return_value.__exit__.return_value = False
+            # BBBB (17) exceeds a Teen cap -> whole file blocked.
+            self.assertTrue(appmod._file_blocked_by_cap(1, 13, True))
+            # Both within an adult cap -> allowed.
+            self.assertFalse(appmod._file_blocked_by_cap(1, 18, True))
+
+    # --- _blocked_title_ids_for_cap --------------------------------------
+    def test_blocked_title_ids_for_cap(self):
+        metadata = {'rating_by_title_id': {'A': 0, 'B': 17, 'C': None}}
+        with patch.object(appmod, '_get_cached_titles_metadata', return_value=metadata):
+            blocked = appmod._blocked_title_ids_for_cap(13, True)
+            self.assertEqual(blocked, {'B', 'C'})
+            blocked_open = appmod._blocked_title_ids_for_cap(13, False)
+            self.assertEqual(blocked_open, {'B'})
+            self.assertEqual(appmod._blocked_title_ids_for_cap(None, True), set())
+
+    # --- normalize_max_rating (auth) -------------------------------------
+    def test_normalize_max_rating(self):
+        self.assertIsNone(normalize_max_rating(None))
+        self.assertIsNone(normalize_max_rating(''))
+        self.assertIsNone(normalize_max_rating('   '))
+        self.assertIsNone(normalize_max_rating('not-a-number'))
+        self.assertIsNone(normalize_max_rating(99))   # not a valid ESRB age
+        self.assertEqual(normalize_max_rating('13'), 13)
+        self.assertEqual(normalize_max_rating(17), 17)
+        self.assertEqual(normalize_max_rating(0), 0)
+
+
+class TitlesIndexRatingTests(unittest.TestCase):
+    """Verify the titles index coercion helper independent of TitleDB I/O."""
+
+    def setUp(self):
+        try:
+            from app import titles as titlesmod
+        except ModuleNotFoundError as exc:
+            raise unittest.SkipTest(f"Missing dependency for titles tests: {exc}")
+        self.titles = titlesmod
+
+    def test_coerce_rating(self):
+        self.assertIsNone(self.titles._coerce_rating(None))
+        self.assertIsNone(self.titles._coerce_rating(''))
+        self.assertIsNone(self.titles._coerce_rating('x'))
+        self.assertIsNone(self.titles._coerce_rating(-1))
+        self.assertEqual(self.titles._coerce_rating(10), 10)
+        self.assertEqual(self.titles._coerce_rating('17'), 17)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_esrb_filter.py
+++ b/tests/test_esrb_filter.py
@@ -120,6 +120,13 @@ class EsrbFilterTests(unittest.TestCase):
             self.assertEqual(blocked_open, {'B'})
             self.assertEqual(appmod._blocked_title_ids_for_cap(None, True), set())
 
+    def test_allowed_title_ids_for_cap_fails_closed_for_missing_ratings(self):
+        metadata = {'rating_by_title_id': {'A': 0, 'B': 17, 'C': None}}
+        with patch.object(appmod, '_get_cached_titles_metadata', return_value=metadata):
+            self.assertEqual(appmod._allowed_title_ids_for_cap(13), {'A'})
+        with patch.object(appmod, '_get_cached_titles_metadata', return_value={'rating_by_title_id': {}}):
+            self.assertEqual(appmod._allowed_title_ids_for_cap(13), set())
+
     # --- normalize_max_rating (auth) -------------------------------------
     def test_normalize_max_rating(self):
         self.assertIsNone(normalize_max_rating(None))


### PR DESCRIPTION
## Summary
Adds an optional per-user **ESRB (age) content filter**, so specific accounts can be restricted to titles at or below a chosen rating (e.g. a child account that only sees E / E10+ / T content). Fully backward compatible — behaviour is unchanged until an admin sets a cap on a user.

## Motivation
The only per-user authorization today is the `admin` / `shop` / `backup` flags (plus `frozen`); there's no way to scope *which titles* a user can see or download. This adds that, reusing rating data already present in TitleDB.

## What changed
- **Rating data:** TitleDB entries already carry a `rating` field (the eShop minimum-age integer, e.g. Breath of the Wild = 10 = E10+). It was being dropped during indexing. The titles SQLite index now stores `rating` and `get_game_info()` returns it. An index schema-version bump forces a one-time rebuild.
- **Per-user cap:** new `User.max_rating` column (NULL = unrestricted), added via the existing runtime `ALTER TABLE` pattern (`ensure_user_client_schema`) — no Alembic migration needed.
- **Configurable unrated policy:** new `content_filter.block_unrated` setting (default **true** = fail-closed: titles with no known rating are hidden from capped users), with an admin toggle on the Settings page.
- **Enforcement on all content surfaces** (filter compares numerically, so it also works for PEGI-region data):
  - `/api/get_game/<id>` download gate → **403** when over cap (hard boundary; gates on the most restrictive title for multicontent files).
  - Tinfoil shop file list and `/api/shop/sections` (per-cap-aware caching).
  - Web browse `/api/titles` + discovery sections.
- **Admin UI:** a "Max rating" dropdown (No limit / E / E10+ / T / M / AO) on the user create + edit forms, plus a per-user badge.

## Compatibility / migration
- Existing installs: `max_rating` column added on startup; all existing users default to unrestricted. No behaviour change until a cap is set.
- TitleDB index rebuilds itself once on next load to populate `rating`.

## Tests
- New `tests/test_esrb_filter.py` (14 cases: rating coercion, the allow/deny truth table incl. fail-closed vs fail-open, multicontent gating, section/blocked-set filtering, `normalize_max_rating`).
- Full suite (`python -m unittest discover -s tests`) passes.

## Notes for reviewers
- UI change is two small additions (users-page dropdown + a settings toggle); happy to add screenshots if useful.
- Line endings in a few touched files are mixed (CRLF/LF) upstream; the diff preserves original endings on unchanged lines so it stays minimal (684 insertions / 39 deletions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)