### PR TITLE
fix: don't drop version-less releases in automatic downloads (#102)

### DIFF
--- a/app/downloads/prowlarr.py
+++ b/app/downloads/prowlarr.py
@@ -258,9 +258,14 @@ def pick_best_result(results, title_id=None, version=None, min_seeders=0, min_ag
         filtered = [item for item in filtered if str(item.get("protocol") or "").strip().lower() in allowed]
     if require_exact_version and version is not None:
         expected_version = int(version)
+        # Only drop results whose title advertises a *different* internal version
+        # token. Releases whose title carries no parseable internal version (the
+        # common case for scene names that use a marketing version like "v1.2.0")
+        # are kept here; the exact update file is enforced later at download time
+        # via versioning.select_update_entry_ids(expected_version=...).
         filtered = [
             item for item in filtered
-            if _extract_internal_version_token(item.get("title")) == expected_version
+            if _extract_internal_version_token(item.get("title")) in (None, expected_version)
         ]
     if not filtered:
         return None

--- a/tests/test_downloads_prowlarr_version_gate.py
+++ b/tests/test_downloads_prowlarr_version_gate.py
@@ -1,0 +1,63 @@
+import unittest
+
+_IMPORT_ERROR = None
+try:
+    from app.downloads.prowlarr import pick_best_result
+except ModuleNotFoundError as exc:  # optional deps (flask/sqlalchemy) absent
+    _IMPORT_ERROR = exc
+
+
+def _usenet_result(title):
+    return {
+        "title": title,
+        "protocol": "usenet",
+        "download_url": "https://indexer.example/file.nzb",
+        "seeders": 0,
+        "age_minutes": 120,
+    }
+
+
+# Internal Switch version integer for update "2.0.0".
+EXPECTED_VERSION = 131072
+
+
+class ExactVersionGateTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        if _IMPORT_ERROR is not None:
+            raise unittest.SkipTest(f"Missing dependency: {_IMPORT_ERROR}")
+
+    def _pick(self, title, require_exact_version):
+        return pick_best_result(
+            [_usenet_result(title)],
+            title_id="0100000000010000",
+            version=EXPECTED_VERSION,
+            min_seeders=0,
+            min_age_minutes=0,
+            allowed_protocols=["usenet"],
+            require_exact_version=require_exact_version,
+        )
+
+    def test_automatic_keeps_release_without_internal_version_token(self):
+        # Regression for #102: normal scene titles carry a marketing version
+        # ("v1.2.0"), not the internal token, so the automatic path used to drop
+        # every result and queue nothing. The exact file is enforced later at
+        # download time, so a tokenless title must survive the search gate.
+        result = self._pick("Pokemon Scarlet Update v1.2.0 NSW-VENOM", require_exact_version=True)
+        self.assertIsNotNone(result)
+
+    def test_automatic_still_drops_release_advertising_a_different_version(self):
+        result = self._pick("Some Game [v65536] NSW-GRP", require_exact_version=True)
+        self.assertIsNone(result)
+
+    def test_automatic_keeps_release_with_matching_internal_token(self):
+        result = self._pick("Some Game [v131072] NSW-GRP", require_exact_version=True)
+        self.assertIsNotNone(result)
+
+    def test_manual_keeps_release_without_token(self):
+        result = self._pick("Pokemon Scarlet Update v1.2.0 NSW-VENOM", require_exact_version=False)
+        self.assertIsNotNone(result)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Fixes #102

### Problem
Automatic downloads never reach the download client, while a **manual** search for the same title queues fine (confirmed by multiple users in #102).

### Root cause
The automatic path (`_process_downloads` → `_search_and_queue`) uses the default `require_exact_version=True`, whereas the manual path passes `False`. In `pick_best_result` the exact-version gate required the release **title** to contain the internal Switch version token (`[vN]`) equal to the requested version:

```python
if _extract_internal_version_token(item.get("title")) == expected_version
```

Normal scene releases name updates with a *marketing* version (e.g. `v1.2.0`), so `extract_internal_update_version()` returns `None`, every result is filtered out → `"No matching results found"` → nothing is queued.

### Fix
Keep results whose title carries **no** parseable internal version token; only drop titles that advertise a *different* version. The exact update file is still enforced later at download time via `versioning.select_update_entry_ids(expected_version=...)`, so this does not risk grabbing the wrong version.

```python
if _extract_internal_version_token(item.get("title")) in (None, expected_version)
```

### Testing
Adds `tests/test_downloads_prowlarr_version_gate.py`:
- automatic path keeps a token-less release (regression),
- automatic path still drops a release advertising a *different* `[vN]`,
- automatic path keeps a matching `[vN]`,
- manual path keeps token-less releases.

Generated with [Claude Code](https://claude.ai/code)