### PR TITLE
fix: organize to library base directory for Flat preset (#122)

### DIFF
--- a/app/library.py
+++ b/app/library.py
@@ -1115,6 +1115,16 @@ def _sanitize_relative_path(path_value, fallback='Other'):
         return _sanitize_component(fallback)
     return os.path.join(*clean_parts)
 
+def _is_base_dir_template(rendered):
+    # True when a rendered folder template refers only to the current/base
+    # directory (e.g. ".", "./", ".."). Such a template means "no subfolder";
+    # the file belongs directly in the library base directory. Without this the
+    # "." used by the Flat preset would be stripped by _sanitize_relative_path
+    # and fall through to the 'Other' fallback.
+    raw = str(rendered or '').strip().replace('\\', '/')
+    parts = [part for part in raw.split('/') if part]
+    return bool(parts) and all(part in ('.', '..') for part in parts)
+
 def _safe_int(value, default=0):
     try:
         return int(value)
@@ -1630,15 +1640,22 @@ def _build_destination(library_path, file_entry, app, title_name, dlc_name, acti
 
     folder_rel = _render_template(folder_tpl, template_vars_common)
     if not folder_rel:
+        # No folder template configured -> default to a per-title folder.
         folder_rel = _sanitize_component(f"{safe_title} [{safe_title_id}]")
-    folder_rel = _sanitize_relative_path(folder_rel, fallback='Other')
+        folder_rel = _sanitize_relative_path(folder_rel, fallback='Other')
+    elif _is_base_dir_template(folder_rel):
+        # Template explicitly targets the library base directory (e.g. "." in the
+        # Flat preset) -> place the file directly under library_path, no subfolder.
+        folder_rel = ''
+    else:
+        folder_rel = _sanitize_relative_path(folder_rel, fallback='Other')
 
     filename = _render_template(filename_tpl, template_vars_filename)
     if not filename:
         filename = file_entry.filename or f"{safe_title} [{safe_title_id}] [UNKNOWN].{safe_ext}"
     filename = _sanitize_component(filename)
 
-    folder = os.path.join(library_path, folder_rel)
+    folder = os.path.join(library_path, folder_rel) if folder_rel else library_path
     return folder, filename
 
 def organize_library(dry_run=False, verbose=False, detail_limit=200):

--- a/tests/test_library_flat_preset.py
+++ b/tests/test_library_flat_preset.py
@@ -1,0 +1,63 @@
+import os
+import unittest
+from types import SimpleNamespace
+
+_IMPORT_ERROR = None
+try:
+    from app.constants import APP_TYPE_BASE
+    from app.library import _build_destination, _is_base_dir_template
+except ModuleNotFoundError as exc:  # optional deps (flask/sqlalchemy) absent
+    _IMPORT_ERROR = exc
+
+
+class FlatPresetBaseFolderTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        if _IMPORT_ERROR is not None:
+            raise unittest.SkipTest(f"Missing dependency: {_IMPORT_ERROR}")
+
+    def _dest(self, folder_tpl):
+        app = SimpleNamespace(
+            app_type=APP_TYPE_BASE,
+            app_version="0",
+            app_id="",  # empty -> skip versions.txt / titledb lookups
+            title=SimpleNamespace(title_id="01000CA004DCA000"),
+        )
+        file_entry = SimpleNamespace(filename="Human Fall Flat.xci", extension="xci")
+        template = {
+            "base": {
+                "folder": folder_tpl,
+                "filename": "{title} [{title_id}] [BASE][v{version}].{ext}",
+            }
+        }
+        return _build_destination(
+            "/games", file_entry, app, "Human Fall Flat", None, active_template=template
+        )
+
+    def test_flat_preset_dot_places_file_in_base_directory(self):
+        # Regression for #122: the Flat preset uses folder="." which must map to
+        # the library base directory, not /games/Other.
+        folder, _filename = self._dest(".")
+        self.assertEqual(folder, "/games")
+
+    def test_named_folder_template_unchanged(self):
+        folder, _filename = self._dest("{title} [{title_id}]")
+        self.assertEqual(folder, os.path.join("/games", "Human Fall Flat [01000CA004DCA000]"))
+
+    def test_default_preset_subfolder_unchanged(self):
+        folder, _filename = self._dest("{title} [{title_id}]/Base")
+        self.assertEqual(
+            folder, os.path.join("/games", "Human Fall Flat [01000CA004DCA000]", "Base")
+        )
+
+    def test_is_base_dir_template_detection(self):
+        self.assertTrue(_is_base_dir_template("."))
+        self.assertTrue(_is_base_dir_template("./"))
+        self.assertTrue(_is_base_dir_template(".."))
+        self.assertFalse(_is_base_dir_template("{title}"))
+        self.assertFalse(_is_base_dir_template(""))
+        self.assertFalse(_is_base_dir_template("Base"))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Fixes #122

### Problem
Organizing with the **Flat** preset (or otherwise targeting the library base directory) moves every file into `<library>/Other` instead of the base directory. Setting an explicit folder name works around it.

### Root cause
The Flat preset sets `folder: "."` meaning "no subfolder, place directly in the library base directory". In `_build_destination` the rendered `"."` is truthy (so the empty-template fallback is skipped), and then `_sanitize_relative_path(".")` strips the `.` segment, collapses to empty and returns the `'Other'` fallback.

### Fix
Detect folder templates that refer only to the current/base directory (`.`, `./`, `..`) via a new `_is_base_dir_template()` helper and map them to an empty relative path, so the file is placed directly under `library_path`. Named subfolders, per-title folders and the empty-template default are unchanged.

### Testing
Adds `tests/test_library_flat_preset.py`:
- `.` → library base directory (regression),
- `{title} [{title_id}]/Base` and named folders unchanged,
- `_is_base_dir_template()` unit coverage.

Generated with [Claude Code](https://claude.ai/code)