### PR TITLE
fix: Resolve Startup Failure Due To Alembic Multiple Head Revisions

### DIFF
--- a/app/migrations/versions/48e539769ef3_merge_heads_7b2a4d9e1f2c_and_.py
+++ b/app/migrations/versions/48e539769ef3_merge_heads_7b2a4d9e1f2c_and_.py
@@ -1,0 +1,27 @@
+"""Merge heads 7b2a4d9e1f2c and b1c2d3e4f5a6
+
+Revision ID: 48e539769ef3
+Revises: 7b2a4d9e1f2c, b1c2d3e4f5a6
+
+This merge reconciles:
+- 7b2a4d9e1f2c (Added client UID/login fields to user table)
+- b1c2d3e4f5a6 (Added title request users relation table)
+
+"""
+
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision = '48e539769ef3'
+down_revision = ('7b2a4d9e1f2c', 'b1c2d3e4f5a6')
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    pass
+
+
+def downgrade():
+    pass


### PR DESCRIPTION
Merge parallel database migrations 7b2a4d9e1f2c and b1c2d3e4f5a6, which both branched from 9f3a12c7b4d2.

These heads were introduced by:
  - Commit e8aaec1 ("Track client UID and last login"): Added client login tracking fields (7b2a4d9e1f2c).
  - Commit cab276a ("Updated and improved game request feature"): Added request relations and join table (b1c2d3e4f5a6).

This merge migration script sets both branches as parents in the `down_revision` tuple:
  down_revision = ('7b2a4d9e1f2c', 'b1c2d3e4f5a6')

By designating both heads as parents, it establishes a single converged head revision (48e539769ef3) and allows the application's automatic startup database upgrade (`upgrade head`) to succeed without throwing a MultipleHeads error.

---

Assisted by Antigravity.